### PR TITLE
(598) Add `POST /contacts`

### DIFF
--- a/db/migrations/000098-01-alter-table-shantytowns-add-name.js
+++ b/db/migrations/000098-01-alter-table-shantytowns-add-name.js
@@ -7,7 +7,7 @@ module.exports = {
                 'shantytowns',
                 'name',
                 {
-                    type: Sequelize.TEXT,
+                    type: Sequelize.STRING,
                     allowNull: true,
                 },
                 {
@@ -18,7 +18,7 @@ module.exports = {
                 'ShantytownHistories',
                 'name',
                 {
-                    type: Sequelize.TEXT,
+                    type: Sequelize.STRING,
                     allowNull: true,
                 },
                 {

--- a/db/migrations/000098-01-alter-table-shantytowns-add-name.js
+++ b/db/migrations/000098-01-alter-table-shantytowns-add-name.js
@@ -1,0 +1,46 @@
+
+
+module.exports = {
+    up: (queryInterface, Sequelize) => queryInterface.sequelize.transaction(
+        transaction => Promise.all([
+            queryInterface.addColumn(
+                'shantytowns',
+                'name',
+                {
+                    type: Sequelize.TEXT,
+                    allowNull: true,
+                },
+                {
+                    transaction,
+                },
+            ),
+            queryInterface.addColumn(
+                'ShantytownHistories',
+                'name',
+                {
+                    type: Sequelize.TEXT,
+                    allowNull: true,
+                },
+                {
+                    transaction,
+                },
+            ),
+        ]),
+    ),
+
+    down: queryInterface => queryInterface.sequelize.transaction(
+        transaction => Promise.all([
+            queryInterface.removeColumn(
+                'shantytowns',
+                'name',
+                { transaction },
+            ),
+            queryInterface.removeColumn(
+                'ShantytownHistories',
+                'name',
+                { transaction },
+            ),
+        ]),
+
+    ),
+};

--- a/db/models/shantytowns.js
+++ b/db/models/shantytowns.js
@@ -9,6 +9,10 @@ module.exports = function (sequelize, DataTypes) {
             autoIncrement: true,
             field: 'shantytown_id',
         },
+        name: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+        },
         priority: {
             type: DataTypes.INTEGER,
             allowNull: true,

--- a/db/models/shantytowns.js
+++ b/db/models/shantytowns.js
@@ -10,7 +10,7 @@ module.exports = function (sequelize, DataTypes) {
             field: 'shantytown_id',
         },
         name: {
-            type: DataTypes.TEXT,
+            type: DataTypes.STRING,
             allowNull: true,
         },
         priority: {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
         "eslint-utils": "^1.4.1",
         "exceljs": "^2.0.1",
         "express": "^4.16.4",
+        "express-validator": "^6.6.1",
         "forever": "^1.0.0",
         "js-yaml": "^3.13.1",
         "jsonwebtoken": "^8.4.0",

--- a/server/config/contact_request_types.js
+++ b/server/config/contact_request_types.js
@@ -1,0 +1,7 @@
+module.exports = [
+    'help',
+    'report',
+    'help-request',
+    'info-request',
+    'access-request',
+];

--- a/server/controllers/contactController.js
+++ b/server/controllers/contactController.js
@@ -61,7 +61,6 @@ module.exports = models => ({
                 // ignore
             }
 
-
             return res.status(200).send(result);
         }
 
@@ -70,7 +69,6 @@ module.exports = models => ({
         } catch (err) {
             // ignore
         }
-
 
         return res.status(200).send();
     },

--- a/server/controllers/contactController.js
+++ b/server/controllers/contactController.js
@@ -65,8 +65,13 @@ module.exports = models => ({
             return res.status(200).send(result);
         }
 
-        await sendEmailNewContactMessageToAdmins(req.body, models);
+        try {
+            await sendEmailNewContactMessageToAdmins(req.body, models);
+        } catch (err) {
+            // ignore
+        }
 
-        return res.status(200);
+
+        return res.status(200).send();
     },
 });

--- a/server/controllers/contactController.js
+++ b/server/controllers/contactController.js
@@ -42,12 +42,18 @@ module.exports = models => ({
         // user creation
         if (request_type.includes('access-request') && is_actor) {
             // create the user
-            const result = await userService.create(
-                req.body,
-                [
-                    { key: 'access_request_message', sanitizer: 'string' },
-                ],
-            );
+            const result = await userService.create({
+                last_name: req.body.last_name,
+                first_name: req.body.first_name,
+                email: req.body.email,
+                organization: req.body.organization_full ? req.body.organization_full.id : null,
+                new_association: req.body.new_association === true,
+                new_association_name: req.body.new_association_name || null,
+                new_association_abbreviation: req.body.new_association_abbreviation || null,
+                departement: req.body.departement || null,
+                position: req.body.position,
+                access_request_message: req.body.access_request_message,
+            });
 
             if (result.error) {
                 return res.status(result.error.code).send(result.error.response);

--- a/server/controllers/contactController.js
+++ b/server/controllers/contactController.js
@@ -39,6 +39,7 @@ module.exports = models => ({
     async contact(req, res) {
         const { request_type, is_actor } = req.body;
 
+        // user creation
         if (request_type.includes('access-request') && is_actor) {
             // create the user
             const result = await userService.create(
@@ -64,6 +65,7 @@ module.exports = models => ({
             return res.status(200).send(result);
         }
 
+        // contact request
         try {
             await sendEmailNewContactMessageToAdmins(req.body, models);
         } catch (err) {

--- a/server/controllers/contactController/index.js
+++ b/server/controllers/contactController/index.js
@@ -1,0 +1,72 @@
+const userService = require('#server/services/userService');
+
+const {
+    send: sendMail,
+} = require('#server/utils/mail');
+
+const MAIL_TEMPLATES = {};
+MAIL_TEMPLATES.new_user_confirmation = require('#server/mails/new_user_confirmation');
+MAIL_TEMPLATES.new_user_alert = require('#server/mails/new_user_alert');
+MAIL_TEMPLATES.contact_message = require('#server/mails/contact_message');
+
+
+const sendEmailNewUserConfirmation = async (result) => {
+    await sendMail(result, MAIL_TEMPLATES.new_user_confirmation());
+};
+
+const sendEmailNewUserAlertToAdmins = async (result, models) => {
+    const user = await models.user.findOne(result.id, { extended: true });
+    const admins = await models.user.getAdminsFor(user);
+    const mailTemplate = MAIL_TEMPLATES.new_user_alert(user, new Date());
+
+    for (let i = 0; i < admins.length; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await sendMail(admins[i], mailTemplate);
+    }
+};
+
+const sendEmailNewContactMessageToAdmins = async (data, models) => {
+    const admins = await models.user.getNationalAdmins();
+    const mailTemplate = MAIL_TEMPLATES.contact_message(data, new Date());
+
+    for (let i = 0; i < admins.length; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await sendMail(admins[i], mailTemplate);
+    }
+};
+
+module.exports = models => ({
+    async contact(req, res) {
+        const { request_type, is_actor } = req.body;
+
+        if (request_type.includes('access-request') && is_actor) {
+            // create the user
+            const result = await userService.create(
+                req.body,
+                [
+                    { key: 'access_request_message', sanitizer: 'string' },
+                ],
+            );
+
+            if (result.error) {
+                return res.status(result.error.code).send(result.error.response);
+            }
+
+            try {
+                await Promise.all([
+                    sendEmailNewUserConfirmation(result),
+                    sendEmailNewUserAlertToAdmins(result, models),
+                ]);
+            } catch (err) {
+                // ignore
+            }
+
+
+            return res.status(200).send(result);
+        }
+
+        await sendEmailNewContactMessageToAdmins(req.body, models);
+
+        return res.status(200);
+    },
+});

--- a/server/controllers/townController.js
+++ b/server/controllers/townController.js
@@ -869,7 +869,7 @@ module.exports = (models) => {
                     width: COLUMN_WIDTHS.LARGE,
                 },
                 name: {
-                    title: 'Name',
+                    title: 'Appellation du site',
                     data: ({ name }) => name,
                     width: COLUMN_WIDTHS.SMALL,
                 },

--- a/server/controllers/townController.js
+++ b/server/controllers/townController.js
@@ -176,6 +176,7 @@ module.exports = (models) => {
 
             // create the town
             const {
+                name,
                 priority,
                 address,
                 citycode,
@@ -217,6 +218,7 @@ module.exports = (models) => {
                 let town;
                 await sequelize.transaction(async () => {
                     const baseTown = {
+                        name,
                         priority,
                         latitude,
                         longitude,
@@ -866,6 +868,11 @@ module.exports = (models) => {
                     data: ({ addressDetails }) => addressDetails,
                     width: COLUMN_WIDTHS.LARGE,
                 },
+                name: {
+                    title: 'Name',
+                    data: ({ name }) => name,
+                    width: COLUMN_WIDTHS.SMALL,
+                },
                 fieldType: {
                     title: 'Type de site',
                     data: ({ fieldType }) => fieldType.label,
@@ -1181,6 +1188,7 @@ module.exports = (models) => {
                     properties.departement,
                     properties.city,
                     properties.address,
+                    properties.name,
                 ],
                 lastFrozen: true,
             });

--- a/server/controllers/townController/edit.js
+++ b/server/controllers/townController/edit.js
@@ -130,8 +130,6 @@ module.exports = models => async (req, res) => {
                 updatedBy: req.user.id,
             };
 
-            console.log('before update');
-
             await town.update(
                 Object.assign(
                     {},

--- a/server/controllers/townController/edit.js
+++ b/server/controllers/townController/edit.js
@@ -58,6 +58,7 @@ module.exports = models => async (req, res) => {
     // edit the town
     const {
         priority,
+        name,
         declaredAt,
         builtAt,
         status,
@@ -99,6 +100,7 @@ module.exports = models => async (req, res) => {
     try {
         await sequelize.transaction(async () => {
             const baseTown = {
+                name,
                 priority,
                 declaredAt,
                 builtAt,
@@ -127,6 +129,8 @@ module.exports = models => async (req, res) => {
                 city: citycode,
                 updatedBy: req.user.id,
             };
+
+            console.log('before update');
 
             await town.update(
                 Object.assign(

--- a/server/controllers/townController/helpers/cleanParams.js
+++ b/server/controllers/townController/helpers/cleanParams.js
@@ -150,7 +150,7 @@ module.exports = function cleanParams(body, format) {
     }
 
     return {
-        name,
+        name: trim(name) || null,
         priority: getIntOrNull(priority),
         builtAt: built_at !== '' ? built_at : null,
         status: trim(status),

--- a/server/controllers/townController/helpers/cleanParams.js
+++ b/server/controllers/townController/helpers/cleanParams.js
@@ -26,6 +26,7 @@ module.exports = function cleanParams(body, format) {
     let city;
     let citycode;
     let address;
+    let name;
     let detailed_address;
     let population_total;
     let population_couples;
@@ -60,6 +61,7 @@ module.exports = function cleanParams(body, format) {
 
     if (format === 'camel') {
         ({
+            name,
             priority,
             builtAt: built_at,
             status,
@@ -103,6 +105,7 @@ module.exports = function cleanParams(body, format) {
         } = body);
     } else {
         ({
+            name,
             priority,
             built_at,
             status,
@@ -147,6 +150,7 @@ module.exports = function cleanParams(body, format) {
     }
 
     return {
+        name,
         priority: getIntOrNull(priority),
         builtAt: built_at !== '' ? built_at : null,
         status: trim(status),

--- a/server/controllers/townController/helpers/validateInput.js
+++ b/server/controllers/townController/helpers/validateInput.js
@@ -46,6 +46,7 @@ module.exports = async function validateInput(models, body, user, permission, fo
         priority,
         builtAt,
         address,
+        name,
         city,
         citycode,
         latitude,
@@ -158,6 +159,11 @@ module.exports = async function validateInput(models, body, user, permission, fo
         if (longitude < -180 || longitude > 180) {
             error('address', 'La longitude est invalide');
         }
+    }
+
+    // name
+    if (name !== null && name.length > 35) {
+        error('name', 'L\'appelation du site ne peut pas dépasser 35 caractères');
     }
 
     // field type

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -14,8 +14,6 @@ const {
 const permissionsDescription = require('#server/permissions_description');
 
 const MAIL_TEMPLATES = {};
-MAIL_TEMPLATES.new_user_confirmation = require('#server/mails/new_user_confirmation');
-MAIL_TEMPLATES.new_user_alert = require('#server/mails/new_user_alert');
 MAIL_TEMPLATES.access_granted = require('#server/mails/access_granted');
 MAIL_TEMPLATES.access_denied = require('#server/mails/access_denied');
 MAIL_TEMPLATES.new_password = require('#server/mails/new_password');
@@ -300,46 +298,6 @@ module.exports = models => ({
             return res.status(result.error.code).send(result.error.response);
         }
 
-        return res.status(200).send(result);
-    },
-
-    /**
-     *
-     */
-    async signup(req, res) {
-        // create the user
-        const result = await userService.create(
-            req.body,
-            [
-                { key: 'access_request_message', sanitizer: 'string' },
-            ],
-        );
-
-        if (result.error) {
-            return res.status(result.error.code).send(result.error.response);
-        }
-
-        // send mails
-        try {
-            await sendMail(result, MAIL_TEMPLATES.new_user_confirmation());
-        } catch (error) {
-            // ignore
-        }
-
-        try {
-            const user = await models.user.findOne(result.id, { extended: true });
-            const admins = await models.user.getAdminsFor(user);
-            const mailTemplate = MAIL_TEMPLATES.new_user_alert(user, new Date());
-
-            for (let i = 0; i < admins.length; i += 1) {
-                // eslint-disable-next-line no-await-in-loop
-                await sendMail(admins[i], mailTemplate);
-            }
-        } catch (error) {
-            // ignore
-        }
-
-        // congratulations
         return res.status(200).send(result);
     },
 

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -289,8 +289,18 @@ module.exports = models => ({
     async create(req, res) {
         // create the user
         const result = await userService.create(
-            Object.assign({}, req.body, { access_request_message: null }),
-            [],
+            {
+                last_name: req.body.last_name,
+                first_name: req.body.first_name,
+                email: req.body.email,
+                organization: req.body.organization_full ? req.body.organization_full.id : null,
+                new_association: req.body.new_association === true,
+                new_association_name: req.body.new_association_name || null,
+                new_association_abbreviation: req.body.new_association_abbreviation || null,
+                departement: req.body.departement || null,
+                position: req.body.position,
+                access_request_message: null,
+            },
             req.user.id,
         );
 

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -1,11 +1,12 @@
-const validator = require('validator');
 const semver = require('semver');
 const jwt = require('jsonwebtoken');
-const { sequelize } = require('#db/models');
+const sanitize = require('#server/controllers/userController/helpers/sanitize');
+const checkPassword = require('#server/controllers/userController/helpers/checkPassword');
+const validate = require('#server/controllers/userController/helpers/validate');
+const userService = require('#server/services/userService');
 
 const {
-    generateAccessTokenFor, hashPassword, generateSalt, getAccountActivationLink,
-    getPasswordResetLink,
+    generateAccessTokenFor, hashPassword, getAccountActivationLink, getPasswordResetLink,
 } = require('#server/utils/auth');
 const {
     send: sendMail,
@@ -27,31 +28,6 @@ function trim(str) {
     }
 
     return str.replace(/^\s*|\s*$/g, '');
-}
-
-function checkPassword(str) {
-    if (!str) {
-        return ['Le mot de passe est obligatoire'];
-    }
-
-    const errors = [];
-    if (str.length < 12) {
-        errors.push('Le mot de passe doit comporter 12 caractères ou plus');
-    }
-
-    if (!(/[a-z]/g).test(str)) {
-        errors.push('Le mot de passe doit comporter une lettre minuscule');
-    }
-
-    if (!(/[A-Z]/g).test(str)) {
-        errors.push('Le mot de passe doit comporter une lettre majuscule');
-    }
-
-    if (!(/[^a-zA-Z]/g).test(str)) {
-        errors.push('Le mot de passe doit comporter un caractère non alphabétique');
-    }
-
-    return errors;
 }
 
 function fromOptionToPermissions(user, option, dataJustice) {
@@ -102,13 +78,6 @@ function fromOptionToPermissions(user, option, dataJustice) {
     }
 }
 
-class MultipleError extends Error {
-    constructor(messages, ...args) {
-        super('Plusieurs erreurs sont survenues', ...args);
-        this.messages = messages;
-    }
-}
-
 function fromOptionsToPermissions(user, options) {
     if (options.length === 0) {
         return [];
@@ -123,909 +92,836 @@ function fromOptionsToPermissions(user, options) {
     ], []);
 }
 
-module.exports = (models) => {
-    const sanitizers = {
-        string(str) {
-            return typeof str === 'string' ? validator.trim(str) : null;
-        },
+module.exports = models => ({
+    async list(req, res) {
+        try {
+            const users = await models.user.findAll(req.user);
+            res.status(200).send(users);
+        } catch (error) {
+            res.status(500).send({
+                error: {
+                    user_message: 'Une erreur est survenue lors de la récupération des données en base',
+                    developer_message: error.message,
+                },
+            });
+        }
+    },
 
-        bool(bool) {
-            return typeof bool === 'boolean' ? bool : false;
-        },
+    async get(req, res) {
+        try {
+            const user = await models.user.findOne(req.params.id, { extended: true }, req.user);
+            res.status(200).send(user);
+        } catch (error) {
+            res.status(500).send({
+                error: {
+                    user_message: 'Une erreur est survenue lors de la récupération des données en base',
+                    developer_message: error.message,
+                },
+            });
+        }
+    },
 
-        integer(int) {
-            const parsed = parseInt(int, 10);
-            return Number.isInteger(parsed) ? parsed : null;
-        },
+    async signin(req, res) {
+        const { email, password } = req.body;
 
-        object(obj) {
-            return typeof obj === 'object' ? obj : null;
-        },
-    };
-
-    const validators = {
-        last_name(data) {
-            if (data.last_name === null || data.last_name === '') {
-                throw new Error('Le nom est obligatoire');
-            }
-        },
-
-        first_name(data) {
-            if (data.first_name === null || data.first_name === '') {
-                throw new Error('Le prénom est obligatoire');
-            }
-        },
-
-        async email(data, checkUnicity = true) {
-            if (data.email === null || data.email === '') {
-                throw new Error('Le courriel est obligatoire');
-            }
-
-            if (!validator.isEmail(data.email)) {
-                throw new Error('Le courriel est invalide');
-            }
-
-            if (checkUnicity === true) {
-                let user = null;
-                try {
-                    user = await models.user.findOneByEmail(data.email);
-                } catch (error) {
-                    throw new Error('Une erreur est survenue lors de la vérification de votre courriel');
-                }
-
-                if (user !== null) {
-                    throw new Error('Un utilisateur existe déjà pour ce courriel');
-                }
-            }
-        },
-
-        async organization_category(data) {
-            if (data.organization_category === null) {
-                throw new Error('La structure est obligatoire');
-            }
-
-            let category = null;
-            try {
-                category = await models.organizationCategory.findOneById(data.organization_category);
-            } catch (error) {
-                throw new Error('Une erreur est survenue lors de la vérification de la structure sélectionnée');
-            }
-
-            if (category === null) {
-                throw new Error('La structure sélectionnée n\'existe pas en base de données');
-            }
-        },
-
-        position(data) {
-            if (data.position === null || data.position === '') {
-                throw new Error('La fonction est obligatoire');
-            }
-        },
-
-        phone(data) {
-            if (data.phone === null || data.phone === '') {
-                return;
-            }
-
-            if (!/^0[0-9]{9}$/g.test(data.phone)) {
-                throw new Error('Le téléphone doit être une suite de 10 chiffres');
-            }
-        },
-
-        password(data) {
-            if (data.password === null || data.password === '') {
-                throw new Error('Le mot de passe est obligatoire');
-            }
-
-            const passwordErrors = checkPassword(data.password);
-            if (passwordErrors.length > 0) {
-                throw new MultipleError(passwordErrors);
-            }
-        },
-
-        access_request_message(data) {
-            if (data.access_request_message === null || data.access_request_message === '') {
-                throw new Error('Le message est obligatoire');
-            }
-        },
-
-        legal(data) {
-            if (data.legal !== true) {
-                throw new Error('Vous devez confirmer que les données saisies l\'ont été avec votre accord');
-            }
-        },
-
-        async organization_type(data) {
-            if (data.organization_type === null) {
-                throw new Error('Le type de structure est obligatoire');
-            }
-
-            let type = null;
-            try {
-                type = await models.organizationType.findOneById(data.organization_type);
-            } catch (error) {
-                throw new Error('Une erreur est survenue lors de la vérification du type de structure sélectionné');
-            }
-
-            if (type === null) {
-                throw new Error('Le type de structure sélectionné n\'existe pas en base de données');
-            }
-
-            if (type.organization_category !== data.organization_category) {
-                throw new Error('La structure et le type de structure sélectionnés ne se correspondent pas');
-            }
-        },
-
-        async organization_public(data) {
-            if (data.organization_public === null) {
-                throw new Error('Le territoire de rattachement est obligatoire');
-            }
-
-            let organization = null;
-            try {
-                organization = await models.organization.findOneById(data.organization_public);
-            } catch (error) {
-                throw new Error('Une erreur est survenue lors de la vérification du territoire de rattachement');
-            }
-
-            if (organization === null) {
-                throw new Error('Le territoire de rattachement sélectionné n\'existe pas en base de données');
-            }
-
-            if (organization.fk_type !== data.organization_type) {
-                throw new Error('Le territoire de rattachement sélectionné ne correspond à aucune structure en base de données');
-            }
-
-            Object.assign(data, { organization: organization.id });
-        },
-
-        async territorial_collectivity(data) {
-            if (data.territorial_collectivity === null) {
-                throw new Error('Le nom de la structure est obligatoire');
-            }
-
-            let organization = null;
-            try {
-                organization = await models.organization.findOneByLocation(
-                    data.territorial_collectivity.category,
-                    data.territorial_collectivity.data.type,
-                    data.territorial_collectivity.data.code,
-                );
-            } catch (error) {
-                throw new Error('Une erreur est survenue lors de la vérification du nom de la structure');
-            }
-
-            if (organization === null) {
-                throw new Error('La structure sélectionnée n\'existe pas en base de données');
-            }
-
-            if (organization.fk_category !== data.organization_category) {
-                throw new Error('La structure sélectionnée n’est pas une collectivité territoriale');
-            }
-
-            Object.assign(data, { organization: organization.id });
-        },
-
-        async organization_administration(data) {
-            if (data.organization_administration === null) {
-                throw new Error('Le nom de la structure est obligatoire');
-            }
-
-            let organization = null;
-            try {
-                organization = await models.organization.findOneById(data.organization_administration);
-            } catch (error) {
-                throw new Error('Une erreur est survenue lors de la vérification du nom de la structure');
-            }
-
-            if (organization === null) {
-                throw new Error('La structure sélectionnée n\'existe pas en base de données');
-            }
-
-            if (organization.fk_category !== data.organization_category) {
-                throw new Error('La structure sélectionnée n’est pas une administration centrale');
-            }
-
-            Object.assign(data, { organization: organization.id });
-        },
-
-        async association(data) {
-            if (data.association === null || data.association === '') {
-                throw new Error('Le nom de la structure est obligatoire');
-            }
-
-            if (data.association === 'Autre') {
-                return;
-            }
-
-            let association;
-            try {
-                association = await models.organization.findAssociationName(data.association);
-            } catch (error) {
-                throw new Error('Une erreur est survenue lors de la vérification du nom de l\'association');
-            }
-
-            if (association === null) {
-                throw new Error('L\'association sélectionnée n\'a pas été trouvée en base de données');
-            }
-        },
-
-        async newAssociationName(data) {
-            if (data.association !== 'Autre') {
-                return;
-            }
-
-            if (data.newAssociationName === null || data.newAssociationName === '') {
-                throw new Error('Le nom complet de l\'association est obligatoire');
-            }
-
-            let association;
-            try {
-                association = await models.organization.findAssociationName(data.newAssociationName);
-            } catch (error) {
-                throw new Error('Une erreur est survenue lors de la vérification du nom complet de l\'association');
-            }
-
-            if (association !== null) {
-                throw new Error('Il existe déjà une association enregistrée sous ce nom');
-            }
-        },
-
-        newAssociationAbbreviation() { },
-
-        async departement(data) {
-            if (data.departement === null) {
-                throw new Error('Le territoire de rattachement est obligatoire');
-            }
-
-            let departement;
-            try {
-                departement = await models.departement.findOne(data.departement);
-            } catch (error) {
-                throw new Error('Une erreur est survenue lors de la vérification du territoire de rattachement');
-            }
-
-            if (departement === null) {
-                throw new Error('Le terrtoire de rattachement sélectionné n\'existe pas en base de données');
-            }
-        },
-    };
-
-    function sanitize(data, fields) {
-        return fields.reduce((acc, { key, sanitizer }) => Object.assign(acc, {
-            [key]: sanitizers[sanitizer](data[key]),
-        }), {});
-    }
-
-    async function validate(data, fields) {
-        const errors = {};
-
-        for (let i = 0; i < fields.length; i += 1) {
-            const { key, validatorOptions } = fields[i];
-
-            try {
-                // eslint-disable-next-line no-await-in-loop
-                await validators[key].apply(validators, [data, ...(validatorOptions || [])]);
-            } catch (error) {
-                if (error instanceof MultipleError) {
-                    errors[key] = error.messages;
-                } else {
-                    errors[key] = [error.message];
-                }
-            }
+        if (typeof email !== 'string') {
+            return res.status(400).send({
+                success: false,
+                error: {
+                    user_message: 'Ces identifiants sont incorrects',
+                    developer_message: 'The email address must be a string',
+                    fields: {
+                        email: ['L\'adresse e-mail est invalide'],
+                    },
+                },
+            });
         }
 
-        return errors;
-    }
-
-    async function validateCreationInput(req, extendedData = {}, extendedFields = []) {
-        const rawData = Object.assign({
-            last_name: req.body.last_name,
-            first_name: req.body.first_name,
-            email: req.body.email,
-            organization_category: req.body.organization_category,
-            position: req.body.position,
-            legal: req.body.legal,
-            organization_type: req.body.organization_type,
-            organization_public: req.body.organization_public,
-            territorial_collectivity: req.body.territorial_collectivity,
-            association: req.body.association,
-            newAssociationName: req.body.newAssociationName,
-            newAssociationAbbreviation: req.body.newAssociationAbbreviation,
-            departement: req.body.departement,
-            organization_administration: req.body.organization_administration,
-        }, extendedData);
-
-        // get the list of fields to be validated
-        const fields = [
-            ...[
-                { key: 'last_name', sanitizer: 'string' },
-                { key: 'first_name', sanitizer: 'string' },
-                { key: 'email', sanitizer: 'string' },
-                { key: 'organization_category', sanitizer: 'string' },
-                { key: 'position', sanitizer: 'string' },
-                { key: 'legal', sanitizer: 'bool' },
-            ],
-            ...extendedFields,
-        ];
-
-        const specificFields = {
-            public_establishment() {
-                return [
-                    { key: 'organization_type', sanitizer: 'integer' },
-                    { key: 'organization_public', sanitizer: 'integer' },
-                ];
-            },
-
-            territorial_collectivity() {
-                return [
-                    { key: 'territorial_collectivity', sanitizer: 'object' },
-                ];
-            },
-
-            association() {
-                return [
-                    { key: 'association', sanitizer: 'string' },
-                    { key: 'newAssociationName', sanitizer: 'string' },
-                    { key: 'newAssociationAbbreviation', sanitizer: 'string' },
-                    { key: 'departement', sanitizer: 'string' },
-                ];
-            },
-
-            administration() {
-                return [
-                    { key: 'organization_administration', sanitizer: 'integer' },
-                ];
-            },
-        };
-
-        if (Object.prototype.hasOwnProperty.call(specificFields, req.body.organization_category)) {
-            fields.push(...specificFields[req.body.organization_category]());
+        if (typeof password !== 'string') {
+            return res.status(400).send({
+                success: false,
+                error: {
+                    user_message: 'Ces identifiants sont incorrects',
+                    developer_message: 'The password must be a string',
+                    fields: {
+                        password: ['Le mot de passe est invalide'],
+                    },
+                },
+            });
         }
 
-        // sanitize
-        const sanitizedData = sanitize(rawData, fields);
-
-        // validate
-        return {
-            sanitizedData,
-            errors: await validate(sanitizedData, fields),
-        };
-    }
-
-    async function createUser(data) {
-        const userId = await sequelize.transaction(async (t) => {
-            // create association if necessary
-            if (data.organization_category === 'association') {
-                let create = null;
-                let organization = null;
-                if (data.association === 'Autre') {
-                    create = {
-                        name: data.newAssociationName,
-                        abbreviation: data.newAssociationAbbreviation || null,
-                    };
-                } else {
-                    organization = await models.organization.findOneAssociation(
-                        data.association,
-                        data.departement,
-                    );
-
-                    if (organization === null) {
-                        const association = await models.organization.findAssociationName(data.association);
-
-                        create = {
-                            name: association !== null ? association.name : data.association,
-                            abbreviation: association !== null ? association.abbreviation : null,
-                        };
-                    }
-                }
-
-                if (create !== null) {
-                    const type = (await models.organizationType.findByCategory('association'))[0].id;
-                    [[organization]] = (await models.organization.create(
-                        create.name,
-                        create.abbreviation,
-                        type,
-                        null,
-                        data.departement,
-                        null,
-                        null,
-                        false,
-                        t,
-                    ));
-                }
-
-                Object.assign(data, { organization: organization.id });
-            }
-
-            // create the user himself
-            return models.user.create(Object.assign(data, {
-                salt: generateSalt(),
-            }), t);
+        const user = await models.user.findOneByEmail(email, {
+            auth: true,
         });
 
-        return models.user.findOne(userId);
-    }
-
-    return {
-        async list(req, res) {
-            try {
-                const users = await models.user.findAll(req.user);
-                res.status(200).send(users);
-            } catch (error) {
-                res.status(500).send({
-                    error: {
-                        user_message: 'Une erreur est survenue lors de la récupération des données en base',
-                        developer_message: error.message,
-                    },
-                });
-            }
-        },
-
-        async get(req, res) {
-            try {
-                const user = await models.user.findOne(req.params.id, { extended: true }, req.user);
-                res.status(200).send(user);
-            } catch (error) {
-                res.status(500).send({
-                    error: {
-                        user_message: 'Une erreur est survenue lors de la récupération des données en base',
-                        developer_message: error.message,
-                    },
-                });
-            }
-        },
-
-        async signin(req, res) {
-            const { email, password } = req.body;
-
-            if (typeof email !== 'string') {
-                return res.status(400).send({
-                    success: false,
-                    error: {
-                        user_message: 'Ces identifiants sont incorrects',
-                        developer_message: 'The email address must be a string',
-                        fields: {
-                            email: ['L\'adresse e-mail est invalide'],
-                        },
-                    },
-                });
-            }
-
-            if (typeof password !== 'string') {
-                return res.status(400).send({
-                    success: false,
-                    error: {
-                        user_message: 'Ces identifiants sont incorrects',
-                        developer_message: 'The password must be a string',
-                        fields: {
-                            password: ['Le mot de passe est invalide'],
-                        },
-                    },
-                });
-            }
-
-            const user = await models.user.findOneByEmail(email, {
-                auth: true,
+        if (user === null) {
+            return res.status(403).send({
+                success: false,
+                error: {
+                    user_message: 'Ces identifiants sont incorrects',
+                    developer_message: 'The given credentials do not match an existing user',
+                },
             });
+        }
 
-            if (user === null) {
-                return res.status(403).send({
-                    success: false,
-                    error: {
-                        user_message: 'Ces identifiants sont incorrects',
-                        developer_message: 'The given credentials do not match an existing user',
-                    },
-                });
-            }
-
-            if (user.status !== 'active') {
-                return res.status(400).send({
-                    success: false,
-                    error: {
-                        user_message: 'Votre compte doit être activé avant utilisation',
-                        developer_message: 'The user is not activated yet',
-                    },
-                });
-            }
-
-            const hashedPassword = hashPassword(password, user.salt);
-            if (hashedPassword !== user.password) {
-                return res.status(403).send({
-                    success: false,
-                    error: {
-                        user_message: 'Ces identifiants sont incorrects',
-                        developer_message: 'The given credentials do not match an existing user',
-                    },
-                });
-            }
-
-            return res.status(200).send({
-                success: true,
-                token: generateAccessTokenFor(user),
+        if (user.status !== 'active') {
+            return res.status(400).send({
+                success: false,
+                error: {
+                    user_message: 'Votre compte doit être activé avant utilisation',
+                    developer_message: 'The user is not activated yet',
+                },
             });
-        },
+        }
 
-        renewToken(req, res) {
-            const { id: userId, email } = req.user;
-
-            return res.status(200).send({
-                token: generateAccessTokenFor({ id: userId, email }),
+        const hashedPassword = hashPassword(password, user.salt);
+        if (hashedPassword !== user.password) {
+            return res.status(403).send({
+                success: false,
+                error: {
+                    user_message: 'Ces identifiants sont incorrects',
+                    developer_message: 'The given credentials do not match an existing user',
+                },
             });
-        },
+        }
 
-        /**
+        return res.status(200).send({
+            success: true,
+            token: generateAccessTokenFor(user),
+        });
+    },
+
+    renewToken(req, res) {
+        const { id: userId, email } = req.user;
+
+        return res.status(200).send({
+            token: generateAccessTokenFor({ id: userId, email }),
+        });
+    },
+
+    /**
          * Returns information about... yourself!
          */
-        async me(req, res) {
-            const user = await models.user.findOne(req.user.id, {
-                extended: true,
-            });
-            return res.status(200).send(user);
-        },
+    async me(req, res) {
+        const user = await models.user.findOne(req.user.id, {
+            extended: true,
+        });
+        return res.status(200).send(user);
+    },
 
-        /**
+    /**
          * Updates some data about the current user
          */
-        async edit(req, res) {
-            // find the user
-            const { id: userId } = req.user;
-            const user = await models.user.findOne(userId, { auth: true });
+    async edit(req, res) {
+        // find the user
+        const { id: userId } = req.user;
+        const user = await models.user.findOne(userId, { auth: true });
 
-            if (user === null) {
-                return res.status(500).send({
-                    error: {
-                        user_message: 'Impossible de trouver vos informations en bases de données.',
-                        developer_message: `User #${userId} does not exist`,
-                    },
-                });
+        if (user === null) {
+            return res.status(500).send({
+                error: {
+                    user_message: 'Impossible de trouver vos informations en bases de données.',
+                    developer_message: `User #${userId} does not exist`,
+                },
+            });
+        }
+
+        // validate the input
+        const errors = {};
+
+        // first name
+        const firstName = trim(req.body.first_name);
+        if (firstName === null || firstName === '') {
+            errors.first_name = ['Le prénom est obligatoire '];
+        }
+
+        // last name
+        const lastName = trim(req.body.last_name);
+        if (lastName === null || lastName === '') {
+            errors.last_name = ['Le nom de famille est obligatoire '];
+        }
+
+        // password
+        if (req.body.password) {
+            const passwordErrors = checkPassword(req.body.password);
+            if (passwordErrors.length > 0) {
+                errors.password = passwordErrors;
             }
+        }
 
-            // validate the input
-            const errors = {};
+        if (Object.keys(errors).length > 0) {
+            return res.status(400).send({
+                error: {
+                    developer_message: 'The submitted data contains errors',
+                    user_message: 'Certaines données sont invalides',
+                    fields: errors,
+                },
+            });
+        }
 
-            // first name
-            const firstName = trim(req.body.first_name);
-            if (firstName === null || firstName === '') {
-                errors.first_name = ['Le prénom est obligatoire '];
-            }
+        // actually update the user
+        const data = {
+            first_name: firstName,
+            last_name: lastName,
+        };
 
-            // last name
-            const lastName = trim(req.body.last_name);
-            if (lastName === null || lastName === '') {
-                errors.last_name = ['Le nom de famille est obligatoire '];
-            }
+        if (req.body.password) {
+            data.password = hashPassword(req.body.password, user.salt);
+        }
 
-            // password
-            if (req.body.password) {
-                const passwordErrors = checkPassword(req.body.password);
-                if (passwordErrors.length > 0) {
-                    errors.password = passwordErrors;
-                }
-            }
-
-            if (Object.keys(errors).length > 0) {
-                return res.status(400).send({
-                    error: {
-                        developer_message: 'The submitted data contains errors',
-                        user_message: 'Certaines données sont invalides',
-                        fields: errors,
-                    },
-                });
-            }
-
-            // actually update the user
-            const data = {
+        try {
+            await models.user.update(userId, data);
+            return res.status(200).send({
+                id: user.userId,
+                email: user.email,
                 first_name: firstName,
                 last_name: lastName,
-            };
-
-            if (req.body.password) {
-                data.password = hashPassword(req.body.password, user.salt);
-            }
-
-            try {
-                await models.user.update(userId, data);
-                return res.status(200).send({
-                    id: user.userId,
-                    email: user.email,
-                    first_name: firstName,
-                    last_name: lastName,
-                    departement: user.departement,
-                });
-            } catch (error) {
-                return res.status(500).send({
-                    error: {
-                        user_message: 'Une erreur est survenue dans l\'écriture de vos informations en base de données.',
-                        developer_message: error.message,
-                    },
-                });
-            }
-        },
-
-        async create(req, res) {
-            // validate input
-            const { sanitizedData, errors } = await validateCreationInput(req);
-
-            if (Object.keys(errors).length > 0) {
-                return res.status(400).send({
-                    error: {
-                        user_message: 'Certaines informations saisies sont incorrectes',
-                        developer_message: 'Input data is invalid',
-                        fields: errors,
-                    },
-                });
-            }
-
-            // insert user into database
-            let user;
-            try {
-                user = await createUser(Object.assign({}, sanitizedData, {
-                    access_request_message: null,
-                    created_by: req.user.id,
-                }));
-            } catch (error) {
-                return res.status(500).send({
-                    error: {
-                        user_message: 'Une erreur est survenue lors de l\'écriture en base de données',
-                        developer_message: 'Failed inserting the new user into database',
-                    },
-                });
-            }
-
-            // congratulations
-            return res.status(200).send(user);
-        },
-
-        /**
-         *
-         */
-        async signup(req, res) {
-            // validate input
-            const { sanitizedData, errors } = await validateCreationInput(
-                req,
-                {
-                    access_request_message: req.body.access_request_message,
+                departement: user.departement,
+            });
+        } catch (error) {
+            return res.status(500).send({
+                error: {
+                    user_message: 'Une erreur est survenue dans l\'écriture de vos informations en base de données.',
+                    developer_message: error.message,
                 },
-                [
-                    { key: 'access_request_message', sanitizer: 'string' },
-                ],
-            );
+            });
+        }
+    },
 
-            if (Object.keys(errors).length > 0) {
-                return res.status(400).send({
-                    error: {
-                        user_message: 'Certaines informations saisies sont incorrectes',
-                        developer_message: 'Input data is invalid',
-                        fields: errors,
-                    },
-                });
+    async create(req, res) {
+        // create the user
+        const result = await userService.create(
+            Object.assign({}, req.body, { access_request_message: null }),
+            [],
+            req.user.id,
+        );
+
+        if (result.error) {
+            return res.status(result.error.code).send(result.error.response);
+        }
+
+        return res.status(200).send(result);
+    },
+
+    /**
+     *
+     */
+    async signup(req, res) {
+        // create the user
+        const result = await userService.create(
+            req.body,
+            [
+                { key: 'access_request_message', sanitizer: 'string' },
+            ],
+        );
+
+        if (result.error) {
+            return res.status(result.error.code).send(result.error.response);
+        }
+
+        // send mails
+        try {
+            await sendMail(result, MAIL_TEMPLATES.new_user_confirmation());
+        } catch (error) {
+            // ignore
+        }
+
+        try {
+            const user = await models.user.findOne(result.id, { extended: true });
+            const admins = await models.user.getAdminsFor(user);
+            const mailTemplate = MAIL_TEMPLATES.new_user_alert(user, new Date());
+
+            for (let i = 0; i < admins.length; i += 1) {
+                // eslint-disable-next-line no-await-in-loop
+                await sendMail(admins[i], mailTemplate);
             }
+        } catch (error) {
+            // ignore
+        }
 
-            // insert user into database
-            let simpleUser;
+        // congratulations
+        return res.status(200).send(result);
+    },
+
+    async setDefaultExport(req, res) {
+        const { export: exportValue } = req.body;
+
+        if (exportValue === undefined) {
+            return res.status(400).send({
+                success: false,
+                error: {
+                    user_message: 'Les nouvelles préférences d\'export sont manquantes',
+                    developer_message: 'The new default export value is missing',
+                },
+            });
+        }
+
+        try {
+            await models.user.update(req.user.id, {
+                defaultExport: exportValue,
+            });
+        } catch (error) {
+            return res.status(500).send({
+                success: false,
+                error: {
+                    user_message: 'La sauvegarde de vos préférences a échoué',
+                    developer_message: `Failed to store the new default-export into database: ${error.message}`,
+                },
+            });
+        }
+
+        return res.status(200).send({
+            success: true,
+        });
+    },
+
+    async checkActivationToken(req, res) {
+        if (!req.params.token) {
+            return res.status(400).send({
+                error: {
+                    user_message: 'Le jeton d\'activation est manquant',
+                    developer_message: 'The activation token is missing',
+                },
+            });
+        }
+
+        let decoded;
+        try {
+            decoded = jwt.verify(req.params.token, authConfig.secret);
+        } catch (error) {
+            return res.status(400).send({
+                error: {
+                    user_message: 'Le jeton d\'activation est invalide ou expiré.\nNous vous invitons à contacter l\'administrateur local qui vous a envoyé le mail avec ce lien d\'activation.',
+                    developer_message: 'The activation token is either invalid or expired',
+                },
+            });
+        }
+
+        const user = await models.user.findOne(decoded.userId);
+        if (user === null) {
+            return res.status(400).send({
+                error: {
+                    user_message: 'Le jeton d\'activation ne correspond à aucun utilisateur',
+                    developer_message: 'The activation token does not match a real user',
+                },
+            });
+        }
+
+        if (user.status !== 'new') {
+            return res.status(400).send({
+                error: {
+                    user_message: 'Ce compte utilisateur est déjà activé',
+                    developer_message: 'The user is already activated',
+                },
+            });
+        }
+
+        return res.status(200).send({
+            id: user.id,
+            email: user.email,
+        });
+    },
+
+    async checkPasswordToken(req, res) {
+        if (!req.params.token) {
+            return res.status(400).send({
+                error: {
+                    user_message: 'Le jeton d\'identification est manquant',
+                    developer_message: 'The password token is missing',
+                },
+            });
+        }
+
+        let decoded;
+        try {
+            decoded = jwt.verify(req.params.token, authConfig.secret);
+        } catch (error) {
+            return res.status(400).send({
+                error: {
+                    user_message: 'Le jeton d\'identification est invalide ou expiré.\nNous vous invitons à reprendre le formulaire de demande de renouvelement de mot de passe.',
+                    developer_message: 'The password token is either invalid or expired',
+                },
+            });
+        }
+
+        if (decoded.type !== 'password_reset') {
+            return res.status(400).send({
+                error: {
+                    user_message: 'Le jeton d\'identification est invalide',
+                    developer_message: 'The given token is not a password token',
+                },
+            });
+        }
+
+        const user = await models.user.findOne(decoded.userId);
+        if (user === null) {
+            return res.status(400).send({
+                error: {
+                    user_message: 'Le jeton d\'identification ne correspond à aucun utilisateur',
+                    developer_message: 'The password token does not match a real user',
+                },
+            });
+        }
+
+        return res.status(200).send({
+            id: user.id,
+            email: user.email,
+        });
+    },
+
+    async sendActivationLink(req, res) {
+        let user;
+        try {
+            user = await models.user.findOne(req.params.id, { extended: true }, req.user, 'activate');
+        } catch (error) {
+            return res.status(500).send({
+                error: {
+                    user_message: 'Une erreur est survenue lors de la lecture en base de données',
+                    developer_message: error.message,
+                },
+            });
+        }
+
+        if (user === null) {
+            return res.status(404).send({
+                error: {
+                    user_message: 'L\'utilisateur auquel envoyer un accès n\'a pas été trouvé en base de données',
+                    developer_message: null,
+                },
+            });
+        }
+
+        if (user.activated_on !== null) {
+            return res.status(400).send({
+                error: {
+                    user_message: 'L\'utilisateur concerné a déjà été activé',
+                    developer_message: null,
+                },
+            });
+        }
+
+        if (user.organization.active !== true) {
+            const { options } = permissionsDescription[user.role_id];
+            const requestedOptions = options.filter(({ id }) => req.body.options && req.body.options[id] === true);
+
+            // inject additional permissions related to options
+            const additionalPermissions = fromOptionsToPermissions(user, requestedOptions);
             try {
-                simpleUser = await createUser(Object.assign({}, sanitizedData, {
-                    created_by: null,
-                }));
+                await models.organization.setCustomPermissions(user.organization.id, additionalPermissions);
             } catch (error) {
                 return res.status(500).send({
                     error: {
-                        user_message: 'Une erreur est survenue lors de l\'écriture en base de données',
-                        developer_message: 'Failed inserting the new user into database',
-                    },
-                });
-            }
-
-            // send mails
-            try {
-                await sendMail(sanitizedData, MAIL_TEMPLATES.new_user_confirmation());
-            } catch (error) {
-                // ignore
-            }
-
-            try {
-                const user = await models.user.findOne(simpleUser.id, { extended: true });
-                const admins = await models.user.getAdminsFor(user);
-                const mailTemplate = MAIL_TEMPLATES.new_user_alert(user, new Date());
-
-                for (let i = 0; i < admins.length; i += 1) {
-                    // eslint-disable-next-line no-await-in-loop
-                    await sendMail(admins[i], mailTemplate);
-                }
-            } catch (error) {
-                // ignore
-            }
-
-            // congratulations
-            return res.status(200).send(simpleUser);
-        },
-
-        async setDefaultExport(req, res) {
-            const { export: exportValue } = req.body;
-
-            if (exportValue === undefined) {
-                return res.status(400).send({
-                    success: false,
-                    error: {
-                        user_message: 'Les nouvelles préférences d\'export sont manquantes',
-                        developer_message: 'The new default export value is missing',
-                    },
-                });
-            }
-
-            try {
-                await models.user.update(req.user.id, {
-                    defaultExport: exportValue,
-                });
-            } catch (error) {
-                return res.status(500).send({
-                    success: false,
-                    error: {
-                        user_message: 'La sauvegarde de vos préférences a échoué',
-                        developer_message: `Failed to store the new default-export into database: ${error.message}`,
-                    },
-                });
-            }
-
-            return res.status(200).send({
-                success: true,
-            });
-        },
-
-        async checkActivationToken(req, res) {
-            if (!req.params.token) {
-                return res.status(400).send({
-                    error: {
-                        user_message: 'Le jeton d\'activation est manquant',
-                        developer_message: 'The activation token is missing',
-                    },
-                });
-            }
-
-            let decoded;
-            try {
-                decoded = jwt.verify(req.params.token, authConfig.secret);
-            } catch (error) {
-                return res.status(400).send({
-                    error: {
-                        user_message: 'Le jeton d\'activation est invalide ou expiré.\nNous vous invitons à contacter l\'administrateur local qui vous a envoyé le mail avec ce lien d\'activation.',
-                        developer_message: 'The activation token is either invalid or expired',
-                    },
-                });
-            }
-
-            const user = await models.user.findOne(decoded.userId);
-            if (user === null) {
-                return res.status(400).send({
-                    error: {
-                        user_message: 'Le jeton d\'activation ne correspond à aucun utilisateur',
-                        developer_message: 'The activation token does not match a real user',
-                    },
-                });
-            }
-
-            if (user.status !== 'new') {
-                return res.status(400).send({
-                    error: {
-                        user_message: 'Ce compte utilisateur est déjà activé',
-                        developer_message: 'The user is already activated',
-                    },
-                });
-            }
-
-            return res.status(200).send({
-                id: user.id,
-                email: user.email,
-            });
-        },
-
-        async checkPasswordToken(req, res) {
-            if (!req.params.token) {
-                return res.status(400).send({
-                    error: {
-                        user_message: 'Le jeton d\'identification est manquant',
-                        developer_message: 'The password token is missing',
-                    },
-                });
-            }
-
-            let decoded;
-            try {
-                decoded = jwt.verify(req.params.token, authConfig.secret);
-            } catch (error) {
-                return res.status(400).send({
-                    error: {
-                        user_message: 'Le jeton d\'identification est invalide ou expiré.\nNous vous invitons à reprendre le formulaire de demande de renouvelement de mot de passe.',
-                        developer_message: 'The password token is either invalid or expired',
-                    },
-                });
-            }
-
-            if (decoded.type !== 'password_reset') {
-                return res.status(400).send({
-                    error: {
-                        user_message: 'Le jeton d\'identification est invalide',
-                        developer_message: 'The given token is not a password token',
-                    },
-                });
-            }
-
-            const user = await models.user.findOne(decoded.userId);
-            if (user === null) {
-                return res.status(400).send({
-                    error: {
-                        user_message: 'Le jeton d\'identification ne correspond à aucun utilisateur',
-                        developer_message: 'The password token does not match a real user',
-                    },
-                });
-            }
-
-            return res.status(200).send({
-                id: user.id,
-                email: user.email,
-            });
-        },
-
-        async sendActivationLink(req, res) {
-            let user;
-            try {
-                user = await models.user.findOne(req.params.id, { extended: true }, req.user, 'activate');
-            } catch (error) {
-                return res.status(500).send({
-                    error: {
-                        user_message: 'Une erreur est survenue lors de la lecture en base de données',
+                        user_message: 'Une erreur est survenue lors de la sauvegarde des options sélectionnées',
                         developer_message: error.message,
                     },
                 });
             }
+        }
 
-            if (user === null) {
-                return res.status(404).send({
-                    error: {
-                        user_message: 'L\'utilisateur auquel envoyer un accès n\'a pas été trouvé en base de données',
-                        developer_message: null,
-                    },
-                });
-            }
+        const { link: activationLink, expiracyDate } = getAccountActivationLink({
+            id: user.id,
+            email: user.email,
+            activatedBy: req.user.id,
+        });
 
-            if (user.activated_on !== null) {
-                return res.status(400).send({
-                    error: {
-                        user_message: 'L\'utilisateur concerné a déjà été activé',
-                        developer_message: null,
-                    },
-                });
-            }
-
-            if (user.organization.active !== true) {
-                const { options } = permissionsDescription[user.role_id];
-                const requestedOptions = options.filter(({ id }) => req.body.options && req.body.options[id] === true);
-
-                // inject additional permissions related to options
-                const additionalPermissions = fromOptionsToPermissions(user, requestedOptions);
-                try {
-                    await models.organization.setCustomPermissions(user.organization.id, additionalPermissions);
-                } catch (error) {
-                    return res.status(500).send({
-                        error: {
-                            user_message: 'Une erreur est survenue lors de la sauvegarde des options sélectionnées',
-                            developer_message: error.message,
-                        },
-                    });
-                }
-            }
-
-            const { link: activationLink, expiracyDate } = getAccountActivationLink({
-                id: user.id,
-                email: user.email,
-                activatedBy: req.user.id,
+        try {
+            // reload the user to take options into account (they might have changed above)
+            user = await models.user.findOne(req.params.id, { extended: true }, req.user, 'activate');
+            await sendMail(user, MAIL_TEMPLATES.access_granted(user, req.user, activationLink, expiracyDate), req.user);
+        } catch (error) {
+            return res.status(500).send({
+                error: {
+                    user_message: 'Une erreur est survenue lors de l\'envoi du mail',
+                    developer_message: error.message,
+                },
             });
+        }
 
+        try {
+            await models.user.update(req.params.id, {
+                last_activation_link_sent_on: new Date(),
+            });
+        } catch (error) {
+            return res.status(500).send({
+                error: {
+                    user_message: 'Une erreur est survenue lors de l\'écriture en base de données',
+                    developer_message: error.message,
+                },
+            });
+        }
+
+        return res.status(200).send({});
+    },
+
+    async denyAccess(req, res) {
+        let user;
+        try {
+            user = await models.user.findOne(req.params.id, undefined, req.user, 'activate');
+        } catch (error) {
+            return res.status(500).send({
+                error: {
+                    user_message: 'Une erreur est survenue lors de la lecture en base de données',
+                    developer_message: error.message,
+                },
+            });
+        }
+
+        if (user === null) {
+            return res.status(404).send({
+                error: {
+                    user_message: 'L\'utilisateur auquel refuser l\'accès n\'a pas été trouvé en base de données',
+                    developer_message: null,
+                },
+            });
+        }
+
+        if (user.activated_on !== null) {
+            return res.status(400).send({
+                error: {
+                    user_message: 'L\'utilisateur concerné a déjà été activé',
+                    developer_message: null,
+                },
+
+            });
+        }
+
+        if (user.last_activation_link_sent_on !== null) {
+            return res.status(400).send({
+                error: {
+                    user_message: 'La demande d\'accès a déjà été acceptée',
+                    developer_message: null,
+                },
+            });
+        }
+
+        try {
+            await sendMail(user, MAIL_TEMPLATES.access_denied(user, req.user), req.user);
+        } catch (error) {
+            return res.status(500).send({
+                error: {
+                    user_message: 'Une erreur est survenue lors de l\'envoi du mail',
+                    developer_message: error.message,
+                },
+            });
+        }
+
+        try {
+            await models.user.delete(req.params.id);
+        } catch (error) {
+            return res.status(500).send({
+                error: {
+                    user_message: 'Une erreur est survenue lors de la suppression du compte de la base de données',
+                    developer_message: error.message,
+                },
+            });
+        }
+
+        return res.status(200).send({});
+    },
+
+    async activate(req, res) {
+        if (!req.body.token) {
+            return res.status(400).send({
+                error: {
+                    user_message: 'Le jeton d\'activation est manquant',
+                    developer_message: 'The activation token is missing',
+                },
+            });
+        }
+
+        let decoded;
+        try {
+            decoded = jwt.verify(req.body.token, authConfig.secret);
+        } catch (error) {
+            return res.status(400).send({
+                error: {
+                    user_message: 'Le jeton d\'activation est invalide ou expiré',
+                    developer_message: 'The activation token is either invalid or expired',
+                },
+            });
+        }
+
+        const user = await models.user.findOne(decoded.userId, { auth: true });
+        if (user === null) {
+            return res.status(400).send({
+                error: {
+                    user_message: 'Le jeton d\'activation ne correspond à aucun utilisateur',
+                    developer_message: 'The activation token does not match a real user',
+                },
+            });
+        }
+
+        if (user.id !== parseInt(req.params.id, 10)) {
+            return res.status(400).send({
+                error: {
+                    user_message: 'Le jeton d\'activation n\'est pas valide',
+                    developer_message: 'The activation token does not match the user id',
+                },
+            });
+        }
+
+        if (user.status === 'active') {
+            return res.status(400).send({
+                error: {
+                    user_message: 'Ce compte utilisateur est déjà activé',
+                    developer_message: 'The user is already activated',
+                },
+            });
+        }
+
+        const errors = checkPassword(req.body.password);
+        if (errors.length > 0) {
+            return res.status(400).send({
+                error: {
+                    user_message: 'Le mot de passe est invalide',
+                    developer_message: 'Input data is invalid',
+                    fields: {
+                        password: errors,
+                    },
+                },
+            });
+        }
+
+        try {
+            await models.organization.activate(user.organization.id);
+            await models.user.update(user.id, {
+                password: hashPassword(req.body.password, user.salt),
+                fk_status: 'active',
+                activated_by: decoded.activatedBy,
+                activated_on: new Date(),
+            });
+        } catch (error) {
+            return res.status(500).send({
+                error: {
+                    user_message: 'Une erreur est survenue lors de l\'écriture en base de données',
+                    developer_message: 'Failed updating the user',
+                },
+            });
+        }
+
+        return res.status(200).send({});
+    },
+
+    async setNewPassword(req, res) {
+        if (!req.body.token) {
+            return res.status(400).send({
+                error: {
+                    user_message: 'Le jeton d\'identification est manquant',
+                    developer_message: 'The password token is missing',
+                },
+            });
+        }
+
+        let decoded;
+        try {
+            decoded = jwt.verify(req.body.token, authConfig.secret);
+        } catch (error) {
+            return res.status(400).send({
+                error: {
+                    user_message: 'Le jeton d\'identification est invalide ou expiré',
+                    developer_message: 'The password token is either invalid or expired',
+                },
+            });
+        }
+
+        if (decoded.type !== 'password_reset') {
+            return res.status(400).send({
+                error: {
+                    user_message: 'Le jeton d\'identification n\'est pas valide',
+                    developer_message: 'The password token does not match the user id',
+                },
+            });
+        }
+
+        const user = await models.user.findOne(decoded.userId, { auth: true });
+        if (user === null) {
+            return res.status(400).send({
+                error: {
+                    user_message: 'Le jeton d\'identification ne correspond à aucun utilisateur',
+                    developer_message: 'The password token does not match a real user',
+                },
+            });
+        }
+
+        if (user.id !== parseInt(req.params.id, 10)) {
+            return res.status(400).send({
+                error: {
+                    user_message: 'Le jeton d\'identification n\'est pas valide',
+                    developer_message: 'The password token does not match the user id',
+                },
+            });
+        }
+
+        const errors = checkPassword(req.body.password);
+        if (errors.length > 0) {
+            return res.status(400).send({
+                error: {
+                    user_message: 'Le mot de passe est invalide',
+                    developer_message: 'Input data is invalid',
+                    fields: {
+                        password: errors,
+                    },
+                },
+            });
+        }
+
+        try {
+            await models.user.update(user.id, {
+                password: hashPassword(req.body.password, user.salt),
+            });
+        } catch (error) {
+            return res.status(500).send({
+                error: {
+                    user_message: 'Une erreur est survenue lors de l\'écriture en base de données',
+                    developer_message: 'Failed updating the user',
+                },
+            });
+        }
+
+        return res.status(200).send({});
+    },
+
+    async upgrade(req, res) {
+        // ensure the user exists and actually needs an upgrade
+        let user;
+        try {
+            user = await models.user.findOne(req.params.id, { auth: true });
+        } catch (error) {
+            return res.status(500).send({
+                error: {
+                    user_message: 'Une erreur est surenue lors de la lecture de la base de données',
+                    developer_message: error.message,
+                },
+            });
+        }
+
+        if (user === null) {
+            return res.status(404).send({
+                error: {
+                    user_message: 'Votre compte n\'a pas été retrouvé en base de données',
+                },
+            });
+        }
+
+        if (user.position !== '') {
+            return res.status(400).send({
+                error: {
+                    user_message: 'Votre compte est déjà à jour',
+                },
+            });
+        }
+
+        // validate the input data
+        const rawData = {
+            position: req.body.position,
+            phone: req.body.phone,
+            password: req.body.password,
+        };
+
+        const fields = [
+            { key: 'position', sanitizer: 'string' },
+            { key: 'phone', sanitizer: 'string' },
+            { key: 'password', sanitizer: 'string' },
+        ];
+
+        const sanitizedData = sanitize(rawData, fields);
+        const errors = await validate(sanitizedData, fields);
+
+        if (Object.keys(errors).length > 0) {
+            return res.status(400).send({
+                error: {
+                    user_message: 'Certaines informations saisies sont incorrectes',
+                    developer_message: 'Input data is invalid',
+                    fields: errors,
+                },
+            });
+        }
+
+        try {
+            await models.user.update(user.id, Object.assign({}, sanitizedData, {
+                password: hashPassword(sanitizedData.password, user.salt),
+            }));
+        } catch (error) {
+            return res.status(500).send({
+                error: {
+                    user_message: 'Une erreur est survenue lors de l\'écriture en base de données',
+                    developer_message: error.message,
+                },
+            });
+        }
+
+        return res.status(200).send({});
+    },
+
+    async remove(req, res) {
+        let user;
+        try {
+            user = await models.user.findOne(req.params.id, undefined, req.user, 'deactivate');
+        } catch (error) {
+            return res.status(500).send({
+                error: {
+                    user_message: 'Une erreur est survenue lors de la lecture en base de données',
+                    developer_message: error.message,
+                },
+            });
+        }
+
+        if (user === null) {
+            return res.status(404).send({
+                error: {
+                    user_message: 'L\'utilisateur auquel supprimer l\'accès n\'a pas été trouvé en base de données',
+                    developer_message: null,
+                },
+            });
+        }
+
+        try {
+            await models.user.deactivate(req.params.id);
+        } catch (error) {
+            return res.status(500).send({
+                error: {
+                    user_message: 'Une erreur est survenue lors de la suppression du compte de la base de données',
+                    developer_message: error.message,
+                },
+            });
+        }
+
+        return res.status(200).send({});
+    },
+
+    async requestNewPassword(req, res) {
+        const data = { email: req.body.email };
+        const fields = [
+            { key: 'email', sanitizer: 'string', validatorOptions: [false] },
+        ];
+        const sanitizedData = sanitize(data, fields);
+
+        const errors = await validate(sanitizedData, fields);
+        if (Object.keys(errors).length > 0) {
+            return res.status(400).send({
+                error: {
+                    user_message: 'Certaines données sont manquantes ou invalides',
+                    fields: errors,
+                },
+            });
+        }
+
+        let user;
+        try {
+            user = await models.user.findOneByEmail(sanitizedData.email);
+        } catch (error) {
+            return res.status(500).send({
+                error: {
+                    user_message: 'Une erreur est survenue lors de la lecture en base de données',
+                    developer_messaage: error.message,
+                },
+            });
+        }
+
+        if (user !== null) {
             try {
-                // reload the user to take options into account (they might have changed above)
-                user = await models.user.findOne(req.params.id, { extended: true }, req.user, 'activate');
-                await sendMail(user, MAIL_TEMPLATES.access_granted(user, req.user, activationLink, expiracyDate), req.user);
+                const resetLink = getPasswordResetLink(user);
+                await sendMail(user, MAIL_TEMPLATES.new_password(user, resetLink));
             } catch (error) {
                 return res.status(500).send({
                     error: {
@@ -1034,468 +930,73 @@ module.exports = (models) => {
                     },
                 });
             }
+        }
 
-            try {
-                await models.user.update(req.params.id, {
-                    last_activation_link_sent_on: new Date(),
-                });
-            } catch (error) {
-                return res.status(500).send({
-                    error: {
-                        user_message: 'Une erreur est survenue lors de l\'écriture en base de données',
-                        developer_message: error.message,
-                    },
-                });
-            }
+        return res.status(200).send({});
+    },
 
+    async setLastChangelog(req, res) {
+        const changelog = semver.valid(req.body.version);
+        if (changelog === null) {
+            return res.status(400).send({
+                error: {
+                    user_message: 'Le numéro de version passé en paramètre est invalide',
+                },
+            });
+        }
+
+        if (req.user.last_changelog !== null && semver.gte(req.user.last_changelog, changelog)) {
             return res.status(200).send({});
-        },
+        }
 
-        async denyAccess(req, res) {
-            let user;
-            try {
-                user = await models.user.findOne(req.params.id, undefined, req.user, 'activate');
-            } catch (error) {
-                return res.status(500).send({
-                    error: {
-                        user_message: 'Une erreur est survenue lors de la lecture en base de données',
-                        developer_message: error.message,
-                    },
-                });
-            }
+        try {
+            await models.user.update(req.user.id, {
+                last_changelog: changelog,
+            });
+        } catch (error) {
+            return res.status(500).send({
+                error: {
+                    user_message: 'Une erreur est survenue lors de l\'écriture en base de données',
+                },
+            });
+        }
 
-            if (user === null) {
-                return res.status(404).send({
-                    error: {
-                        user_message: 'L\'utilisateur auquel refuser l\'accès n\'a pas été trouvé en base de données',
-                        developer_message: null,
-                    },
-                });
-            }
+        return res.status(200).send({});
+    },
 
-            if (user.activated_on !== null) {
-                return res.status(400).send({
-                    error: {
-                        user_message: 'L\'utilisateur concerné a déjà été activé',
-                        developer_message: null,
-                    },
+    async acceptCharte(req, res) {
+        if (parseInt(req.params.id, 10) !== req.user.id) {
+            return res.status(400).send({
+                user_message: 'Vous ne pouvez pas accepter la charte pour un autre utilisateur que vous-même',
+            });
+        }
 
-                });
-            }
+        const charte = await models.charteEngagement.getLatest();
+        if (charte === null) {
+            return res.status(400).send({
+                user_message: 'Il n\'y a aucune charte à accepter pour le moment',
+            });
+        }
 
-            if (user.last_activation_link_sent_on !== null) {
-                return res.status(400).send({
-                    error: {
-                        user_message: 'La demande d\'accès a déjà été acceptée',
-                        developer_message: null,
-                    },
-                });
-            }
+        if (req.body.version_de_charte !== charte.version) {
+            return res.status(400).send({
+                user_message: 'Une charte plus récente existe, vous devez accepter la charte la plus récente',
+            });
+        }
 
-            try {
-                await sendMail(user, MAIL_TEMPLATES.access_denied(user, req.user), req.user);
-            } catch (error) {
-                return res.status(500).send({
-                    error: {
-                        user_message: 'Une erreur est survenue lors de l\'envoi du mail',
-                        developer_message: error.message,
-                    },
-                });
-            }
-
-            try {
-                await models.user.delete(req.params.id);
-            } catch (error) {
-                return res.status(500).send({
-                    error: {
-                        user_message: 'Une erreur est survenue lors de la suppression du compte de la base de données',
-                        developer_message: error.message,
-                    },
-                });
-            }
-
-            return res.status(200).send({});
-        },
-
-        async activate(req, res) {
-            if (!req.body.token) {
-                return res.status(400).send({
-                    error: {
-                        user_message: 'Le jeton d\'activation est manquant',
-                        developer_message: 'The activation token is missing',
-                    },
-                });
-            }
-
-            let decoded;
-            try {
-                decoded = jwt.verify(req.body.token, authConfig.secret);
-            } catch (error) {
-                return res.status(400).send({
-                    error: {
-                        user_message: 'Le jeton d\'activation est invalide ou expiré',
-                        developer_message: 'The activation token is either invalid or expired',
-                    },
-                });
-            }
-
-            const user = await models.user.findOne(decoded.userId, { auth: true });
-            if (user === null) {
-                return res.status(400).send({
-                    error: {
-                        user_message: 'Le jeton d\'activation ne correspond à aucun utilisateur',
-                        developer_message: 'The activation token does not match a real user',
-                    },
-                });
-            }
-
-            if (user.id !== parseInt(req.params.id, 10)) {
-                return res.status(400).send({
-                    error: {
-                        user_message: 'Le jeton d\'activation n\'est pas valide',
-                        developer_message: 'The activation token does not match the user id',
-                    },
-                });
-            }
-
-            if (user.status === 'active') {
-                return res.status(400).send({
-                    error: {
-                        user_message: 'Ce compte utilisateur est déjà activé',
-                        developer_message: 'The user is already activated',
-                    },
-                });
-            }
-
-            const errors = checkPassword(req.body.password);
-            if (errors.length > 0) {
-                return res.status(400).send({
-                    error: {
-                        user_message: 'Le mot de passe est invalide',
-                        developer_message: 'Input data is invalid',
-                        fields: {
-                            password: errors,
-                        },
-                    },
-                });
-            }
-
-            try {
-                await models.organization.activate(user.organization.id);
-                await models.user.update(user.id, {
-                    password: hashPassword(req.body.password, user.salt),
-                    fk_status: 'active',
-                    activated_by: decoded.activatedBy,
-                    activated_on: new Date(),
-                });
-            } catch (error) {
-                return res.status(500).send({
-                    error: {
-                        user_message: 'Une erreur est survenue lors de l\'écriture en base de données',
-                        developer_message: 'Failed updating the user',
-                    },
-                });
-            }
-
-            return res.status(200).send({});
-        },
-
-        async setNewPassword(req, res) {
-            if (!req.body.token) {
-                return res.status(400).send({
-                    error: {
-                        user_message: 'Le jeton d\'identification est manquant',
-                        developer_message: 'The password token is missing',
-                    },
-                });
-            }
-
-            let decoded;
-            try {
-                decoded = jwt.verify(req.body.token, authConfig.secret);
-            } catch (error) {
-                return res.status(400).send({
-                    error: {
-                        user_message: 'Le jeton d\'identification est invalide ou expiré',
-                        developer_message: 'The password token is either invalid or expired',
-                    },
-                });
-            }
-
-            if (decoded.type !== 'password_reset') {
-                return res.status(400).send({
-                    error: {
-                        user_message: 'Le jeton d\'identification n\'est pas valide',
-                        developer_message: 'The password token does not match the user id',
-                    },
-                });
-            }
-
-            const user = await models.user.findOne(decoded.userId, { auth: true });
-            if (user === null) {
-                return res.status(400).send({
-                    error: {
-                        user_message: 'Le jeton d\'identification ne correspond à aucun utilisateur',
-                        developer_message: 'The password token does not match a real user',
-                    },
-                });
-            }
-
-            if (user.id !== parseInt(req.params.id, 10)) {
-                return res.status(400).send({
-                    error: {
-                        user_message: 'Le jeton d\'identification n\'est pas valide',
-                        developer_message: 'The password token does not match the user id',
-                    },
-                });
-            }
-
-            const errors = checkPassword(req.body.password);
-            if (errors.length > 0) {
-                return res.status(400).send({
-                    error: {
-                        user_message: 'Le mot de passe est invalide',
-                        developer_message: 'Input data is invalid',
-                        fields: {
-                            password: errors,
-                        },
-                    },
-                });
-            }
-
-            try {
-                await models.user.update(user.id, {
-                    password: hashPassword(req.body.password, user.salt),
-                });
-            } catch (error) {
-                return res.status(500).send({
-                    error: {
-                        user_message: 'Une erreur est survenue lors de l\'écriture en base de données',
-                        developer_message: 'Failed updating the user',
-                    },
-                });
-            }
-
-            return res.status(200).send({});
-        },
-
-        async upgrade(req, res) {
-            // ensure the user exists and actually needs an upgrade
-            let user;
-            try {
-                user = await models.user.findOne(req.params.id, { auth: true });
-            } catch (error) {
-                return res.status(500).send({
-                    error: {
-                        user_message: 'Une erreur est surenue lors de la lecture de la base de données',
-                        developer_message: error.message,
-                    },
-                });
-            }
-
-            if (user === null) {
-                return res.status(404).send({
-                    error: {
-                        user_message: 'Votre compte n\'a pas été retrouvé en base de données',
-                    },
-                });
-            }
-
-            if (user.position !== '') {
-                return res.status(400).send({
-                    error: {
-                        user_message: 'Votre compte est déjà à jour',
-                    },
-                });
-            }
-
-            // validate the input data
-            const rawData = {
-                position: req.body.position,
-                phone: req.body.phone,
-                password: req.body.password,
-            };
-
-            const fields = [
-                { key: 'position', sanitizer: 'string' },
-                { key: 'phone', sanitizer: 'string' },
-                { key: 'password', sanitizer: 'string' },
-            ];
-
-            const sanitizedData = sanitize(rawData, fields);
-            const errors = await validate(sanitizedData, fields);
-
-            if (Object.keys(errors).length > 0) {
-                return res.status(400).send({
-                    error: {
-                        user_message: 'Certaines informations saisies sont incorrectes',
-                        developer_message: 'Input data is invalid',
-                        fields: errors,
-                    },
-                });
-            }
-
-            try {
-                await models.user.update(user.id, Object.assign({}, sanitizedData, {
-                    password: hashPassword(sanitizedData.password, user.salt),
-                }));
-            } catch (error) {
-                return res.status(500).send({
-                    error: {
-                        user_message: 'Une erreur est survenue lors de l\'écriture en base de données',
-                        developer_message: error.message,
-                    },
-                });
-            }
-
-            return res.status(200).send({});
-        },
-
-        async remove(req, res) {
-            let user;
-            try {
-                user = await models.user.findOne(req.params.id, undefined, req.user, 'deactivate');
-            } catch (error) {
-                return res.status(500).send({
-                    error: {
-                        user_message: 'Une erreur est survenue lors de la lecture en base de données',
-                        developer_message: error.message,
-                    },
-                });
-            }
-
-            if (user === null) {
-                return res.status(404).send({
-                    error: {
-                        user_message: 'L\'utilisateur auquel supprimer l\'accès n\'a pas été trouvé en base de données',
-                        developer_message: null,
-                    },
-                });
-            }
-
-            try {
-                await models.user.deactivate(req.params.id);
-            } catch (error) {
-                return res.status(500).send({
-                    error: {
-                        user_message: 'Une erreur est survenue lors de la suppression du compte de la base de données',
-                        developer_message: error.message,
-                    },
-                });
-            }
-
-            return res.status(200).send({});
-        },
-
-        async requestNewPassword(req, res) {
-            const data = { email: req.body.email };
-            const fields = [
-                { key: 'email', sanitizer: 'string', validatorOptions: [false] },
-            ];
-            const sanitizedData = sanitize(data, fields);
-
-            const errors = await validate(sanitizedData, fields);
-            if (Object.keys(errors).length > 0) {
-                return res.status(400).send({
-                    error: {
-                        user_message: 'Certaines données sont manquantes ou invalides',
-                        fields: errors,
-                    },
-                });
-            }
-
-            let user;
-            try {
-                user = await models.user.findOneByEmail(sanitizedData.email);
-            } catch (error) {
-                return res.status(500).send({
-                    error: {
-                        user_message: 'Une erreur est survenue lors de la lecture en base de données',
-                        developer_messaage: error.message,
-                    },
-                });
-            }
-
-            if (user !== null) {
-                try {
-                    const resetLink = getPasswordResetLink(user);
-                    await sendMail(user, MAIL_TEMPLATES.new_password(user, resetLink));
-                } catch (error) {
-                    return res.status(500).send({
-                        error: {
-                            user_message: 'Une erreur est survenue lors de l\'envoi du mail',
-                            developer_message: error.message,
-                        },
-                    });
-                }
-            }
-
-            return res.status(200).send({});
-        },
-
-        async setLastChangelog(req, res) {
-            const changelog = semver.valid(req.body.version);
-            if (changelog === null) {
-                return res.status(400).send({
-                    error: {
-                        user_message: 'Le numéro de version passé en paramètre est invalide',
-                    },
-                });
-            }
-
-            if (req.user.last_changelog !== null && semver.gte(req.user.last_changelog, changelog)) {
-                return res.status(200).send({});
-            }
-
+        if (req.user.charte_engagement_a_jour !== true) {
             try {
                 await models.user.update(req.user.id, {
-                    last_changelog: changelog,
+                    charte_engagement_signee: req.body.version_de_charte,
                 });
             } catch (error) {
                 return res.status(500).send({
-                    error: {
-                        user_message: 'Une erreur est survenue lors de l\'écriture en base de données',
-                    },
+                    user_message: 'Une erreur est survenue lors de la mise à jour de la base de données',
+                    developer_message: error.message,
                 });
             }
+        }
 
-            return res.status(200).send({});
-        },
-
-        async acceptCharte(req, res) {
-            if (parseInt(req.params.id, 10) !== req.user.id) {
-                return res.status(400).send({
-                    user_message: 'Vous ne pouvez pas accepter la charte pour un autre utilisateur que vous-même',
-                });
-            }
-
-            const charte = await models.charteEngagement.getLatest();
-            if (charte === null) {
-                return res.status(400).send({
-                    user_message: 'Il n\'y a aucune charte à accepter pour le moment',
-                });
-            }
-
-            if (req.body.version_de_charte !== charte.version) {
-                return res.status(400).send({
-                    user_message: 'Une charte plus récente existe, vous devez accepter la charte la plus récente',
-                });
-            }
-
-            if (req.user.charte_engagement_a_jour !== true) {
-                try {
-                    await models.user.update(req.user.id, {
-                        charte_engagement_signee: req.body.version_de_charte,
-                    });
-                } catch (error) {
-                    return res.status(500).send({
-                        user_message: 'Une erreur est survenue lors de la mise à jour de la base de données',
-                        developer_message: error.message,
-                    });
-                }
-            }
-
-            return res.status(200).send({});
-        },
-    };
-};
+        return res.status(200).send({});
+    },
+});

--- a/server/controllers/userController/helpers/checkPassword.js
+++ b/server/controllers/userController/helpers/checkPassword.js
@@ -1,0 +1,24 @@
+module.exports = function checkPassword(str) {
+    if (!str) {
+        return ['Le mot de passe est obligatoire'];
+    }
+
+    const errors = [];
+    if (str.length < 12) {
+        errors.push('Le mot de passe doit comporter 12 caractères ou plus');
+    }
+
+    if (!(/[a-z]/g).test(str)) {
+        errors.push('Le mot de passe doit comporter une lettre minuscule');
+    }
+
+    if (!(/[A-Z]/g).test(str)) {
+        errors.push('Le mot de passe doit comporter une lettre majuscule');
+    }
+
+    if (!(/[^a-zA-Z]/g).test(str)) {
+        errors.push('Le mot de passe doit comporter un caractère non alphabétique');
+    }
+
+    return errors;
+};

--- a/server/controllers/userController/helpers/sanitize.js
+++ b/server/controllers/userController/helpers/sanitize.js
@@ -1,0 +1,26 @@
+const { trim } = require('validator');
+
+const sanitizers = {
+    string(str) {
+        return typeof str === 'string' ? trim(str) : null;
+    },
+
+    bool(bool) {
+        return typeof bool === 'boolean' ? bool : false;
+    },
+
+    integer(int) {
+        const parsed = parseInt(int, 10);
+        return Number.isInteger(parsed) ? parsed : null;
+    },
+
+    object(obj) {
+        return typeof obj === 'object' ? obj : null;
+    },
+};
+
+module.exports = function sanitize(data, fields) {
+    return fields.reduce((acc, { key, sanitizer }) => Object.assign(acc, {
+        [key]: sanitizers[sanitizer](data[key]),
+    }), {});
+};

--- a/server/controllers/userController/helpers/validate.js
+++ b/server/controllers/userController/helpers/validate.js
@@ -1,0 +1,284 @@
+const { isEmail } = require('validator');
+const checkPassword = require('#server/controllers/userController/helpers/checkPassword');
+const { sequelize } = require('#db/models/index');
+const userModel = require('#server/models/userModel')(sequelize);
+const organizationCategoryModel = require('#server/models/organizationCategoryModel')(sequelize);
+const organizationTypeModel = require('#server/models/organizationTypeModel')(sequelize);
+const organizationModel = require('#server/models/organizationModel')(sequelize);
+const departementModel = require('#server/models/departementModel')(sequelize);
+
+class MultipleError extends Error {
+    constructor(messages, ...args) {
+        super('Plusieurs erreurs sont survenues', ...args);
+        this.messages = messages;
+    }
+}
+
+const validators = {
+    last_name(data) {
+        if (data.last_name === null || data.last_name === '') {
+            throw new Error('Le nom est obligatoire');
+        }
+    },
+
+    first_name(data) {
+        if (data.first_name === null || data.first_name === '') {
+            throw new Error('Le prénom est obligatoire');
+        }
+    },
+
+    async email(data, checkUnicity = true) {
+        if (data.email === null || data.email === '') {
+            throw new Error('Le courriel est obligatoire');
+        }
+
+        if (!isEmail(data.email)) {
+            throw new Error('Le courriel est invalide');
+        }
+
+        if (checkUnicity === true) {
+            let user = null;
+            try {
+                user = await userModel.findOneByEmail(data.email);
+            } catch (error) {
+                throw new Error('Une erreur est survenue lors de la vérification de votre courriel');
+            }
+
+            if (user !== null) {
+                throw new Error('Un utilisateur existe déjà pour ce courriel');
+            }
+        }
+    },
+
+    async organization_category(data) {
+        if (data.organization_category === null) {
+            throw new Error('La structure est obligatoire');
+        }
+
+        let category = null;
+        try {
+            category = await organizationCategoryModel.findOneById(data.organization_category);
+        } catch (error) {
+            throw new Error('Une erreur est survenue lors de la vérification de la structure sélectionnée');
+        }
+
+        if (category === null) {
+            throw new Error('La structure sélectionnée n\'existe pas en base de données');
+        }
+    },
+
+    position(data) {
+        if (data.position === null || data.position === '') {
+            throw new Error('La fonction est obligatoire');
+        }
+    },
+
+    phone(data) {
+        if (data.phone === null || data.phone === '') {
+            return;
+        }
+
+        if (!/^0[0-9]{9}$/g.test(data.phone)) {
+            throw new Error('Le téléphone doit être une suite de 10 chiffres');
+        }
+    },
+
+    password(data) {
+        if (data.password === null || data.password === '') {
+            throw new Error('Le mot de passe est obligatoire');
+        }
+
+        const passwordErrors = checkPassword(data.password);
+        if (passwordErrors.length > 0) {
+            throw new MultipleError(passwordErrors);
+        }
+    },
+
+    access_request_message(data) {
+        if (data.access_request_message === null || data.access_request_message === '') {
+            throw new Error('Le message est obligatoire');
+        }
+    },
+
+    legal(data) {
+        if (data.legal !== true) {
+            throw new Error('Vous devez confirmer que les données saisies l\'ont été avec votre accord');
+        }
+    },
+
+    async organization_type(data) {
+        if (data.organization_type === null) {
+            throw new Error('Le type de structure est obligatoire');
+        }
+
+        let type = null;
+        try {
+            type = await organizationTypeModel.findOneById(data.organization_type);
+        } catch (error) {
+            throw new Error('Une erreur est survenue lors de la vérification du type de structure sélectionné');
+        }
+
+        if (type === null) {
+            throw new Error('Le type de structure sélectionné n\'existe pas en base de données');
+        }
+
+        if (type.organization_category !== data.organization_category) {
+            throw new Error('La structure et le type de structure sélectionnés ne se correspondent pas');
+        }
+    },
+
+    async organization_public(data) {
+        if (data.organization_public === null) {
+            throw new Error('Le territoire de rattachement est obligatoire');
+        }
+
+        let organization = null;
+        try {
+            organization = await organizationModel.findOneById(data.organization_public);
+        } catch (error) {
+            throw new Error('Une erreur est survenue lors de la vérification du territoire de rattachement');
+        }
+
+        if (organization === null) {
+            throw new Error('Le territoire de rattachement sélectionné n\'existe pas en base de données');
+        }
+
+        if (organization.fk_type !== data.organization_type) {
+            throw new Error('Le territoire de rattachement sélectionné ne correspond à aucune structure en base de données');
+        }
+
+        Object.assign(data, { organization: organization.id });
+    },
+
+    async territorial_collectivity(data) {
+        if (data.territorial_collectivity === null) {
+            throw new Error('Le nom de la structure est obligatoire');
+        }
+
+        let organization = null;
+        try {
+            organization = await organizationModel.findOneByLocation(
+                data.territorial_collectivity.category,
+                data.territorial_collectivity.data.type,
+                data.territorial_collectivity.data.code,
+            );
+        } catch (error) {
+            throw new Error('Une erreur est survenue lors de la vérification du nom de la structure');
+        }
+
+        if (organization === null) {
+            throw new Error('La structure sélectionnée n\'existe pas en base de données');
+        }
+
+        if (organization.fk_category !== data.organization_category) {
+            throw new Error('La structure sélectionnée n’est pas une collectivité territoriale');
+        }
+
+        Object.assign(data, { organization: organization.id });
+    },
+
+    async organization_administration(data) {
+        if (data.organization_administration === null) {
+            throw new Error('Le nom de la structure est obligatoire');
+        }
+
+        let organization = null;
+        try {
+            organization = await organizationModel.findOneById(data.organization_administration);
+        } catch (error) {
+            throw new Error('Une erreur est survenue lors de la vérification du nom de la structure');
+        }
+
+        if (organization === null) {
+            throw new Error('La structure sélectionnée n\'existe pas en base de données');
+        }
+
+        if (organization.fk_category !== data.organization_category) {
+            throw new Error('La structure sélectionnée n’est pas une administration centrale');
+        }
+
+        Object.assign(data, { organization: organization.id });
+    },
+
+    async association(data) {
+        if (data.association === null || data.association === '') {
+            throw new Error('Le nom de la structure est obligatoire');
+        }
+
+        if (data.association === 'Autre') {
+            return;
+        }
+
+        let association;
+        try {
+            association = await organizationModel.findAssociationName(data.association);
+        } catch (error) {
+            throw new Error('Une erreur est survenue lors de la vérification du nom de l\'association');
+        }
+
+        if (association === null) {
+            throw new Error('L\'association sélectionnée n\'a pas été trouvée en base de données');
+        }
+    },
+
+    async newAssociationName(data) {
+        if (data.association !== 'Autre') {
+            return;
+        }
+
+        if (data.newAssociationName === null || data.newAssociationName === '') {
+            throw new Error('Le nom complet de l\'association est obligatoire');
+        }
+
+        let association;
+        try {
+            association = await organizationModel.findAssociationName(data.newAssociationName);
+        } catch (error) {
+            throw new Error('Une erreur est survenue lors de la vérification du nom complet de l\'association');
+        }
+
+        if (association !== null) {
+            throw new Error('Il existe déjà une association enregistrée sous ce nom');
+        }
+    },
+
+    newAssociationAbbreviation() { },
+
+    async departement(data) {
+        if (data.departement === null) {
+            throw new Error('Le territoire de rattachement est obligatoire');
+        }
+
+        let departement;
+        try {
+            departement = await departementModel.findOne(data.departement);
+        } catch (error) {
+            throw new Error('Une erreur est survenue lors de la vérification du territoire de rattachement');
+        }
+
+        if (departement === null) {
+            throw new Error('Le terrtoire de rattachement sélectionné n\'existe pas en base de données');
+        }
+    },
+};
+
+module.exports = async function validate(data, fields) {
+    const errors = {};
+
+    for (let i = 0; i < fields.length; i += 1) {
+        const { key, validatorOptions } = fields[i];
+
+        try {
+            // eslint-disable-next-line no-await-in-loop
+            await validators[key].apply(validators, [data, ...(validatorOptions || [])]);
+        } catch (error) {
+            if (error instanceof MultipleError) {
+                errors[key] = error.messages;
+            } else {
+                errors[key] = [error.message];
+            }
+        }
+    }
+
+    return errors;
+};

--- a/server/loaders/expressLoader.js
+++ b/server/loaders/expressLoader.js
@@ -8,6 +8,10 @@ const bodyParser = require('body-parser');
  * @returns {Function} An express callback that encapsulates the original one around a Promise
  */
 function asyncHandler(fn) {
+    if (typeof fn !== 'function') {
+        return fn;
+    }
+
     return (req, res, next) => Promise.resolve(fn(req, res, next)).catch(next);
 }
 

--- a/server/loaders/routesLoader.js
+++ b/server/loaders/routesLoader.js
@@ -180,12 +180,10 @@ module.exports = (app) => {
     );
     app.post(
         '/plans',
-        [
-            middlewares.auth.authenticate,
-            (...args) => middlewares.auth.checkPermissions(['plan.create'], ...args),
-            middlewares.charte.check,
-            middlewares.appVersion.sync,
-        ],
+        middlewares.auth.authenticate,
+        (...args) => middlewares.auth.checkPermissions(['plan.create'], ...args),
+        middlewares.charte.check,
+        middlewares.appVersion.sync,
         controllers.plan.create,
     );
     app.post(

--- a/server/loaders/routesLoader.js
+++ b/server/loaders/routesLoader.js
@@ -6,6 +6,7 @@ const { sequelize } = require('#db/models');
 const models = require('#server/models')(sequelize);
 const middlewares = require('#server/middlewares')(models);
 const controllers = require('#server/controllers')(models);
+const validators = require('#server/middlewares/validators');
 
 module.exports = (app) => {
     app.use('/assets', express.static(path.resolve(__dirname, '../assets')));
@@ -94,6 +95,8 @@ module.exports = (app) => {
     );
     app.post(
         '/contact',
+        validators.createContact,
+        middlewares.validation,
         controllers.contact.contact,
     );
     app.post(

--- a/server/loaders/routesLoader.js
+++ b/server/loaders/routesLoader.js
@@ -111,6 +111,10 @@ module.exports = (app) => {
         },
     );
     app.post(
+        '/contact',
+        controllers.contact.contact,
+    );
+    app.post(
         '/users/:id/sendActivationLink',
         middlewares.auth.authenticate,
         (...args) => middlewares.auth.checkPermissions(['user.activate'], ...args),

--- a/server/loaders/routesLoader.js
+++ b/server/loaders/routesLoader.js
@@ -91,6 +91,8 @@ module.exports = (app) => {
         (...args) => middlewares.auth.checkPermissions(['user.create'], ...args),
         middlewares.charte.check,
         middlewares.appVersion.sync,
+        validators.createUser,
+        middlewares.validation,
         controllers.user.create,
     );
     app.post(

--- a/server/loaders/routesLoader.js
+++ b/server/loaders/routesLoader.js
@@ -86,29 +86,11 @@ module.exports = (app) => {
     );
     app.post(
         '/users',
-        async (...args) => {
-            const [, res] = args;
-
-            try {
-                await middlewares.auth.authenticate(...args, false);
-            } catch (error) {
-                return controllers.user.signup(...args);
-            }
-
-            try {
-                await middlewares.auth.checkPermissions(['user.create'], ...args, false);
-                await middlewares.charte.check(...args, false);
-            } catch (error) {
-                // @todo: return a detailed error
-                return res.status(500).send({
-                    success: false,
-                    user_message: 'Vous n\'avez pas accés à cette fonctionnalité',
-                });
-            }
-
-            await middlewares.appVersion.sync(...args, false);
-            return controllers.user.create(...args);
-        },
+        middlewares.auth.authenticate,
+        (...args) => middlewares.auth.checkPermissions(['user.create'], ...args),
+        middlewares.charte.check,
+        middlewares.appVersion.sync,
+        controllers.user.create,
     );
     app.post(
         '/contact',

--- a/server/mails/comment_deletion.js
+++ b/server/mails/comment_deletion.js
@@ -1,5 +1,5 @@
-const signature = require('./signature');
 const validator = require('validator');
+const signature = require('./signature');
 const { generateUserSignature } = require('#server/utils/mail');
 const { fromTsToFormat } = require('#server/utils/date');
 
@@ -17,7 +17,7 @@ module.exports = (town, comment, message, administrator) => {
         "${message}".
 
         "${comment.description}"
-        Écrit le ${fromTsToFormat(comment.createdAt, 'd/m/Y')} à ${fromTsToFormat(comment.createdAt, 'h:i')}, concernant le site : ${town.addressSimple || 'Pas d\'adresse précise'}, ${town.city.name}
+        Écrit le ${fromTsToFormat(comment.createdAt, 'd/m/Y')} à ${fromTsToFormat(comment.createdAt, 'h:i')}, concernant le site : ${town.usename}, ${town.city.name}
 
         Pour rappel, conformément à la réglementation relative aux données à caractère personnel, un commentaire doit :
         - être neutre et factuel ;
@@ -56,7 +56,7 @@ module.exports = (town, comment, message, administrator) => {
                                 <td bgcolor="#ffffff" style="border: 1px solid #ccc; padding: 15px 20px;">
                                     ${fromTsToFormat(comment.createdAt, 'd/m/Y')} à ${fromTsToFormat(comment.createdAt, 'h:i')}<br/>
                                     <font style="font-style: italic; font-weight: bold; color: red;"><b>Commentaire supprimé</b></font><br/>
-                                    <font style="font-style: italic; font-weight: bold; color: #ADB9C9;"><b>Site : ${town.addressSimple || 'Pas d\'adresse précise'}, ${town.city.name}</b></font><br/><br/>
+                                    <font style="font-style: italic; font-weight: bold; color: #ADB9C9;"><b>Site : ${town.usename}, ${town.city.name}</b></font><br/><br/>
                                     <table width="100%" border="0" cellpadding="0" cellspacing="0">
                                         <tbody>
                                             <tr>

--- a/server/mails/contact_message.js
+++ b/server/mails/contact_message.js
@@ -1,0 +1,70 @@
+const escape = require('escape-html');
+const { toString: dateToString } = require('#server/utils/date');
+const signature = require('./signature');
+
+
+module.exports = (message, date) => ({
+    Subject: '[ resorption-bidonvilles ] - Vous avez reçu un nouveau message de contact',
+
+    TextPart: `Cher administrateur,
+
+        Vous avez reçu un nouveau message de contact
+        
+        Merci,
+
+        -
+        Date du message : ${dateToString(date)}
+
+        ${message.last_name.toUpperCase()} ${message.first_name}
+        ${message.access_request_message}
+        -
+
+        ${signature.TextPart}`,
+
+    HTMLPart: `<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "">
+        <html>
+            <head>
+                <link href="https://fonts.googleapis.com/css?family=Open+Sans&display=swap" rel="stylesheet">
+            </head>
+
+            <body style="max-width: 600px; width: 600px;" bgcolor="#ffffff">
+                <div class="container" style="font-family: 'Open Sans'; width: 600px;">
+                    <table style="width: 600px; font-family: 'Open Sans'; color: #000000;" border="0" cellpadding="0" cellspacing="0" width="600">
+                        <tbody>
+                            <tr>
+                                <td bgcolor="#ffffff">
+                                    Cher administrateur,<br/>
+                                    <br/>
+                                    Vous avez reçu un nouveau message de contact<br/>
+                                    <br/>
+                                    Merci,<br/>
+                                    <br/>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td bgcolor="#dddddd" style="padding: 10px;">
+                                    <table border="0" cellpadding="0" cellspacing="0">
+                                        <tbody>
+                                            <tr>
+                                                <td bgcolor="#dddddd">Date du messqge : ${dateToString(date)}<br/><br/></td>
+                                            </tr>
+                                            <tr>
+                                                <td bgcolor="#dddddd">${message.last_name.toUpperCase()} ${message.first_name}<br/></td>
+                                            </tr>
+                                            <tr>
+                                                <td bgcolor="#dddddd">${escape(message.access_request_message).replace(/\n/g, '<br/>')}</td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td bgcolor="#ffffff"><br/><br/></td>
+                            </tr>
+                            ${signature.HTMLPart}
+                        </tbody>
+                    </table>
+                </div>
+            </body>
+        </html>`,
+});

--- a/server/middlewares/validationMiddleware.js
+++ b/server/middlewares/validationMiddleware.js
@@ -1,0 +1,16 @@
+const { validationResult } = require('express-validator');
+
+module.exports = () => (req, res, next) => {
+    const errors = validationResult(req);
+
+    if (!errors.isEmpty()) {
+        return res.status(400).send({
+            user_message: 'Certaines données sont incorrectes',
+            fields: errors.array().reduce((acc, { param, msg }) => Object.assign({}, acc, {
+                [param]: [...(acc[param] || []), msg],
+            }), {}),
+        });
+    }
+
+    return next();
+};

--- a/server/middlewares/validators/common/newUser.js
+++ b/server/middlewares/validators/common/newUser.js
@@ -1,0 +1,292 @@
+/* eslint-disable newline-per-chained-call */
+const { body } = require('express-validator');
+
+// models
+const { sequelize } = require('#db/models');
+const organizationCategoryModel = require('#server/models/organizationCategoryModel')(sequelize);
+const organizationTypeModel = require('#server/models/organizationTypeModel')(sequelize);
+const organizationModel = require('#server/models/organizationModel')(sequelize);
+const departementModel = require('#server/models/departementModel')(sequelize);
+const userModel = require('#server/models/userModel')(sequelize);
+
+module.exports = (additionalValidators = [], isAUserCreationCallback = (() => true)) => ([
+    ...additionalValidators,
+
+    body('last_name')
+        .trim()
+        .notEmpty().withMessage('Vous devez préciser le nom'),
+
+    body('first_name')
+        .trim()
+        .notEmpty().withMessage('Vous devez préciser le prénom'),
+
+    body('email')
+        .trim()
+        .notEmpty().withMessage('Vous devez préciser le courriel')
+        .isEmail().withMessage('Ce courriel n\'est pas valide')
+        .normalizeEmail()
+        .if(isAUserCreationCallback)
+        .custom(async (value, { req }) => {
+            let user = null;
+            try {
+                user = await userModel.findOneByEmail(value);
+            } catch (error) {
+                throw new Error('Une erreur est survenue lors de la vérification du courriel');
+            }
+
+            if (user !== null) {
+                throw new Error('Un utilisateur existe déjà pour ce courriel');
+            }
+
+            req.body.user_full = user;
+            return true;
+        }),
+
+    body('organization_category')
+        .if(isAUserCreationCallback)
+        .custom(async (value, { req }) => {
+            if (!value) {
+                throw new Error('Vous devez préciser la structure');
+            }
+
+            let organizationCategory;
+            try {
+                organizationCategory = await organizationCategoryModel.findOneById(value);
+            } catch (error) {
+                throw new Error('Une erreur est survenue lors de la vérification de la structure');
+            }
+
+            if (organizationCategory === null) {
+                throw new Error('La structure que vous avez sélectionnée n\'existe pas en base de données');
+            }
+
+            req.body.organization_category_full = organizationCategory;
+            return true;
+        }),
+
+    body('organization_type')
+        .toInt()
+        .if((value, { req }) => req.body.organization_category_full.uid === 'public_establishment')
+        .custom(async (value, { req }) => {
+            if (!value) {
+                throw new Error('Vous devez préciser le type de structure');
+            }
+
+            let organizationType;
+            try {
+                organizationType = await organizationTypeModel.findOneById(value);
+            } catch (error) {
+                throw new Error('Une erreur est survenue lors de la vérification du type de structure');
+            }
+
+            if (organizationType === null) {
+                throw new Error('Le type de structure que vous avez sélectionné n\'existe pas en base de données');
+            }
+
+            if (organizationType.organization_category !== 'public_establishment') {
+                throw new Error('Le type de structure que vous avez sélectionné est invalide');
+            }
+
+            req.body.organization_type_full = organizationType;
+            return true;
+        }),
+
+    body('organization_public')
+        .toInt()
+        .if((value, { req }) => req.body.organization_type_full !== undefined)
+        .custom(async (value, { req }) => {
+            if (!value) {
+                throw new Error('Vous devez préciser le territoire de rattachement de la structure');
+            }
+
+            let organization;
+            try {
+                organization = await organizationModel.findOneById(value);
+            } catch (error) {
+                throw new Error('Une erreur est survenue lors de la vérification du territoire de rattachement');
+            }
+
+            if (organization === null) {
+                throw new Error('Le territoire de rattachement que vous avez sélectionné n\'existe pas en base de données');
+            }
+
+            if (organization.fk_type !== req.body.organization_type) {
+                throw new Error('Le territoire de rattachement que vous avez sélectionné est invalide');
+            }
+
+            req.body.organization_full = organization;
+            return true;
+        }),
+
+    body('territorial_collectivity')
+        .if((value, { req }) => req.body.organization_category_full.uid === 'territorial_collectivity')
+        .custom(async (value, { req }) => {
+            if (!value) {
+                throw new Error('Vous devez préciser le nom de la structure');
+            }
+
+            let organization;
+            try {
+                organization = await organizationModel.findOneByLocation(
+                    value.category,
+                    value.data.type,
+                    value.data.code,
+                );
+            } catch (error) {
+                throw new Error('Une erreur est survenue lors de la vérification du nom de la structure');
+            }
+
+            if (organization === null) {
+                throw new Error('Le nom de structure que vous avez sélectionné n\'existe pas en base de données');
+            }
+
+            if (organization.fk_category !== 'territorial_collectivity') {
+                throw new Error('Le nom de structure que vous avez sélectionné est invalide');
+            }
+
+            req.body.organization_full = organization;
+            return true;
+        }),
+
+    body('organization_administration')
+        .if((value, { req }) => req.body.organization_category_full.uid === 'administration')
+        .custom(async (value, { req }) => {
+            if (!value) {
+                throw new Error('Vous devez préciser le nom de la structure');
+            }
+
+            let organization;
+            try {
+                organization = await organizationModel.findOneById(value);
+            } catch (error) {
+                throw new Error('Une erreur est survenue lors de la vérification du nom de la structure');
+            }
+
+            if (organization === null) {
+                throw new Error('Le nom de structure que vous avez sélectionné n\'existe pas en base de données');
+            }
+
+            if (organization.fk_category !== 'administration') {
+                throw new Error('Le nom de structure que vous avez sélectionné est invalide');
+            }
+
+            req.body.organization_full = organization;
+            return true;
+        }),
+
+    body('association')
+        .if((value, { req }) => req.body.organization_category_full.uid === 'association')
+        .custom(async (value, { req }) => {
+            if (!value) {
+                throw new Error('Vous devez préciser le nom de la structure');
+            }
+
+            if (value === 'Autre') {
+                return true;
+            }
+
+            let organization;
+            try {
+                organization = await organizationModel.findAssociationName(value);
+            } catch (error) {
+                throw new Error('Une erreur est survenue lors de la vérification du nom de la structure');
+            }
+
+            if (organization === null) {
+                throw new Error('Le nom de structure que vous avez sélectionné n\'existe pas en base de données');
+            }
+
+            req.body.association_name = organization.name;
+            req.body.association_abbreviation = organization.abbreviation;
+
+            return true;
+        }),
+
+    body('new_association_name')
+        .if((value, { req }) => req.body.organization_category_full.uid === 'association' && req.body.association === 'Autre')
+        .trim()
+        .custom(async (value) => {
+            if (!value) {
+                throw new Error('Vous devez préciser le nom complet de l\'association');
+            }
+
+            let organization;
+            try {
+                organization = await organizationModel.findAssociationName(value);
+            } catch (error) {
+                throw new Error('Une erreur est survenue lors de la vérification du nom de la structure');
+            }
+
+            if (organization !== null) {
+                throw new Error('Il existe déjà une association enregistrée sous ce nom');
+            }
+
+            return true;
+        }),
+
+    body('new_association_abbreviation')
+        .if((value, { req }) => req.body.organization_category_full.uid === 'association' && req.body.association === 'Autre')
+        .trim(),
+
+    body('departement')
+        .if((value, { req }) => req.body.organization_category_full.uid === 'association')
+        .custom(async (value, { req }) => {
+            if (!value) {
+                throw new Error('Vous devez préciser le territoire de rattachement');
+            }
+
+            // check the departement
+            let departement;
+            try {
+                departement = await departementModel.findOne(value);
+            } catch (error) {
+                throw new Error('Une erreur est survenue lors de la vérification du département');
+            }
+
+            if (departement === null) {
+                throw new Error('Le territoire de rattachement que vous avez sélectionné n\'existe pas en base de données');
+            }
+
+            // case of an existing association
+            if (req.body.association !== 'Autre') {
+                let association = null;
+                try {
+                    association = await organizationModel.findOneAssociation(
+                        req.body.association,
+                        value,
+                    );
+                } catch (error) {
+                    throw new Error('Une erreur est survenue lors de la vérification du territoire de rattachement');
+                }
+
+                if (association !== null) {
+                    req.body.new_association = false;
+                    req.body.organization_full = association;
+                } else {
+                    req.body.new_association = true;
+                    req.body.new_association_name = req.body.association_name;
+                    req.body.new_association_abbreviation = req.body.association_abbreviation;
+                }
+
+                return true;
+            }
+
+            // case of a brand new association
+            req.body.new_association = true;
+            return true;
+        }),
+
+    body('position')
+        .if(isAUserCreationCallback)
+        .trim()
+        .notEmpty().withMessage('Vous devez préciser la fonction au sein de la structure'),
+
+    body('legal')
+        .custom((value) => {
+            if (value !== true) {
+                throw new Error('Vous devez certifier que ces données personnelles ont été saisies avec l\'accord de leur propriétaire');
+            }
+
+            return true;
+        }),
+]);

--- a/server/middlewares/validators/createContact.js
+++ b/server/middlewares/validators/createContact.js
@@ -82,6 +82,7 @@ module.exports = [
         }),
 
     body('organization_type')
+        .toInt()
         .if((value, { req }) => req.body.organization_category_full.uid === 'public_establishment')
         .custom(async (value, { req }) => {
             if (!value) {
@@ -108,6 +109,7 @@ module.exports = [
         }),
 
     body('organization_public')
+        .toInt()
         .if((value, { req }) => req.body.organization_type_full !== undefined)
         .custom(async (value, { req }) => {
             if (!value) {

--- a/server/middlewares/validators/createContact.js
+++ b/server/middlewares/validators/createContact.js
@@ -1,313 +1,33 @@
 /* eslint-disable newline-per-chained-call */
 const { body } = require('express-validator');
+const newUser = require('./newUser');
+
 const ALLOWED_TYPES = require('#server/config/contact_request_types');
 
-// models
-const { sequelize } = require('#db/models');
-const organizationCategoryModel = require('#server/models/organizationCategoryModel')(sequelize);
-const organizationTypeModel = require('#server/models/organizationTypeModel')(sequelize);
-const organizationModel = require('#server/models/organizationModel')(sequelize);
-const departementModel = require('#server/models/departementModel')(sequelize);
-const userModel = require('#server/models/userModel')(sequelize);
-
-module.exports = [
-    body('last_name')
-        .trim()
-        .notEmpty().withMessage('Vous devez préciser votre nom'),
-
-    body('first_name')
-        .trim()
-        .notEmpty().withMessage('Vous devez préciser votre prénom'),
-
-    body('email')
-        .trim()
-        .notEmpty().withMessage('Vous devez préciser votre courriel')
-        .isEmail().withMessage('Ce courriel n\'est pas valide')
-        .normalizeEmail()
-        .if((value, { req }) => req.body.is_actor === true && req.body.request_type.includes('access-request'))
-        .custom(async (value, { req }) => {
-            let user = null;
-            try {
-                user = await userModel.findOneByEmail(value);
-            } catch (error) {
-                throw new Error('Une erreur est survenue lors de la vérification de votre courriel');
-            }
-
-            if (user !== null) {
-                throw new Error('Un utilisateur existe déjà pour ce courriel');
-            }
-
-            req.body.user_full = user;
-            return true;
-        }),
-
-    body('request_type')
-        .isArray({ min: 1 }).withMessage('Vous devez préciser la ou les raisons de votre prise de contact')
-        .custom((requestTypes) => {
-            if (!Array.isArray(requestTypes)) {
-                return true;
-            }
-
-            const improperValues = requestTypes.filter(type => !ALLOWED_TYPES.includes(type));
-            if (improperValues.length > 0) {
-                throw new Error('Certaines raisons sélectionnées ne sont pas reconnues');
-            }
-
-            return true;
-        }),
-
-    body('is_actor')
-        .isBoolean().withMessage('Vous devez préciser si vous êtes un acteur de la résorption des bidonvilles'),
-
-    body('organization_category')
-        .if((value, { req }) => req.body.is_actor === true && req.body.request_type.includes('access-request'))
-        .custom(async (value, { req }) => {
-            if (!value) {
-                throw new Error('Vous devez préciser votre structure');
-            }
-
-            let organizationCategory;
-            try {
-                organizationCategory = await organizationCategoryModel.findOneById(value);
-            } catch (error) {
-                throw new Error('Une erreur est survenue lors de la vérification de votre structure');
-            }
-
-            if (organizationCategory === null) {
-                throw new Error('La structure que vous avez sélectionnée n\'existe pas en base de données');
-            }
-
-            req.body.organization_category_full = organizationCategory;
-            return true;
-        }),
-
-    body('organization_type')
-        .toInt()
-        .if((value, { req }) => req.body.organization_category_full.uid === 'public_establishment')
-        .custom(async (value, { req }) => {
-            if (!value) {
-                throw new Error('Vous devez préciser le type de votre structure');
-            }
-
-            let organizationType;
-            try {
-                organizationType = await organizationTypeModel.findOneById(value);
-            } catch (error) {
-                throw new Error('Une erreur est survenue lors de la vérification de votre type de structure');
-            }
-
-            if (organizationType === null) {
-                throw new Error('Le type de structure que vous avez sélectionné n\'existe pas en base de données');
-            }
-
-            if (organizationType.organization_category !== 'public_establishment') {
-                throw new Error('Le type de structure que vous avez sélectionné est invalide');
-            }
-
-            req.body.organization_type_full = organizationType;
-            return true;
-        }),
-
-    body('organization_public')
-        .toInt()
-        .if((value, { req }) => req.body.organization_type_full !== undefined)
-        .custom(async (value, { req }) => {
-            if (!value) {
-                throw new Error('Vous devez préciser le territoire de rattachement de votre structure');
-            }
-
-            let organization;
-            try {
-                organization = await organizationModel.findOneById(value);
-            } catch (error) {
-                throw new Error('Une erreur est survenue lors de la vérification de votre territoire de rattachement');
-            }
-
-            if (organization === null) {
-                throw new Error('Le territoire de rattachement que vous avez sélectionné n\'existe pas en base de données');
-            }
-
-            if (organization.fk_type !== req.body.organization_type) {
-                throw new Error('Le territoire de rattachement que vous avez sélectionné est invalide');
-            }
-
-            req.body.organization_full = organization;
-            return true;
-        }),
-
-    body('territorial_collectivity')
-        .if((value, { req }) => req.body.organization_category_full.uid === 'territorial_collectivity')
-        .custom(async (value, { req }) => {
-            if (!value) {
-                throw new Error('Vous devez préciser le nom de votre structure');
-            }
-
-            let organization;
-            try {
-                organization = await organizationModel.findOneByLocation(
-                    value.category,
-                    value.data.type,
-                    value.data.code,
-                );
-            } catch (error) {
-                throw new Error('Une erreur est survenue lors de la vérification du nom de votre structure');
-            }
-
-            if (organization === null) {
-                throw new Error('Le nom de structure que vous avez sélectionné n\'existe pas en base de données');
-            }
-
-            if (organization.fk_category !== 'territorial_collectivity') {
-                throw new Error('Le nom de structure que vous avez sélectionné est invalide');
-            }
-
-            req.body.organization_full = organization;
-            return true;
-        }),
-
-    body('organization_administration')
-        .if((value, { req }) => req.body.organization_category_full.uid === 'administration')
-        .custom(async (value, { req }) => {
-            if (!value) {
-                throw new Error('Vous devez préciser le nom de votre structure');
-            }
-
-            let organization;
-            try {
-                organization = await organizationModel.findOneById(value);
-            } catch (error) {
-                throw new Error('Une erreur est survenue lors de la vérification du nom de votre structure');
-            }
-
-            if (organization === null) {
-                throw new Error('Le nom de structure que vous avez sélectionné n\'existe pas en base de données');
-            }
-
-            if (organization.fk_category !== 'administration') {
-                throw new Error('Le nom de structure que vous avez sélectionné est invalide');
-            }
-
-            req.body.organization_full = organization;
-            return true;
-        }),
-
-    body('association')
-        .if((value, { req }) => req.body.organization_category_full.uid === 'association')
-        .custom(async (value, { req }) => {
-            if (!value) {
-                throw new Error('Vous devez préciser le nom de votre structure');
-            }
-
-            if (value === 'Autre') {
-                return true;
-            }
-
-            let organization;
-            try {
-                organization = await organizationModel.findAssociationName(value);
-            } catch (error) {
-                throw new Error('Une erreur est survenue lors de la vérification du nom de votre structure');
-            }
-
-            if (organization === null) {
-                throw new Error('Le nom de structure que vous avez sélectionné n\'existe pas en base de données');
-            }
-
-            req.body.association_name = organization.name;
-            req.body.association_abbreviation = organization.abbreviation;
-
-            return true;
-        }),
-
-    body('new_association_name')
-        .if((value, { req }) => req.body.organization_category_full.uid === 'association' && req.body.association === 'Autre')
-        .trim()
-        .custom(async (value) => {
-            if (!value) {
-                throw new Error('Vous devez préciser le nom complet de votre association');
-            }
-
-            let organization;
-            try {
-                organization = await organizationModel.findAssociationName(value);
-            } catch (error) {
-                throw new Error('Une erreur est survenue lors de la vérification du nom de votre structure');
-            }
-
-            if (organization !== null) {
-                throw new Error('Il existe déjà une association enregistrée sous ce nom');
-            }
-
-            return true;
-        }),
-
-    body('new_association_abbreviation')
-        .if((value, { req }) => req.body.organization_category_full.uid === 'association' && req.body.association === 'Autre')
-        .trim(),
-
-    body('departement')
-        .if((value, { req }) => req.body.organization_category_full.uid === 'association')
-        .custom(async (value, { req }) => {
-            if (!value) {
-                throw new Error('Vous devez préciser votre territoire de rattachement');
-            }
-
-            // check the departement
-            let departement;
-            try {
-                departement = await departementModel.findOne(value);
-            } catch (error) {
-                throw new Error('Une erreur est survenue lors de la vérification de votre département');
-            }
-
-            if (departement === null) {
-                throw new Error('Le territoire de rattachement que vous avez sélectionné n\'existe pas en base de données');
-            }
-
-            // case of an existing association
-            if (req.body.association !== 'Autre') {
-                let association = null;
-                try {
-                    association = await organizationModel.findOneAssociation(
-                        req.body.association,
-                        value,
-                    );
-                } catch (error) {
-                    throw new Error('Une erreur est survenue lors de la vérification de votre territoire de rattachement');
+module.exports = newUser(
+    [
+        body('request_type')
+            .isArray({ min: 1 }).withMessage('Vous devez préciser la ou les raisons de votre prise de contact')
+            .custom((requestTypes) => {
+                if (!Array.isArray(requestTypes)) {
+                    return true;
                 }
 
-                if (association !== null) {
-                    req.body.new_association = false;
-                    req.body.organization_full = association;
-                } else {
-                    req.body.new_association = true;
-                    req.body.new_association_name = req.body.association_name;
-                    req.body.new_association_abbreviation = req.body.association_abbreviation;
+                const improperValues = requestTypes.filter(type => !ALLOWED_TYPES.includes(type));
+                if (improperValues.length > 0) {
+                    throw new Error('Certaines raisons sélectionnées ne sont pas reconnues');
                 }
 
                 return true;
-            }
+            }),
 
-            // case of a brand new association
-            req.body.new_association = true;
-            return true;
-        }),
+        body('is_actor')
+            .isBoolean().withMessage('Vous devez préciser si vous êtes un acteur de la résorption des bidonvilles'),
 
-    body('position')
-        .if((value, { req }) => req.body.is_actor === true && req.body.request_type.includes('access-request'))
-        .trim()
-        .notEmpty().withMessage('Vous devez préciser votre fonction au sein de la structure'),
+        body('access_request_message')
+            .trim()
+            .notEmpty().withMessage('Vous devez préciser votre message'),
+    ],
 
-    body('access_request_message')
-        .trim()
-        .notEmpty().withMessage('Vous devez préciser votre message'),
-
-    body('legal')
-        .custom((value) => {
-            if (value !== true) {
-                throw new Error('Vous devez certifier que ces données personnelles ont été saisies avec votre accord');
-            }
-
-            return true;
-        }),
-];
+    (value, { req }) => req.body.is_actor === true && req.body.request_type.includes('access-request'),
+);

--- a/server/middlewares/validators/createContact.js
+++ b/server/middlewares/validators/createContact.js
@@ -1,0 +1,302 @@
+/* eslint-disable newline-per-chained-call */
+const { body } = require('express-validator');
+const ALLOWED_TYPES = require('#server/config/contact_request_types');
+
+// models
+const { sequelize } = require('#db/models');
+const organizationCategoryModel = require('#server/models/organizationCategoryModel')(sequelize);
+const organizationTypeModel = require('#server/models/organizationTypeModel')(sequelize);
+const organizationModel = require('#server/models/organizationModel')(sequelize);
+const departementModel = require('#server/models/departementModel')(sequelize);
+const userModel = require('#server/models/userModel')(sequelize);
+
+module.exports = [
+    body('last_name')
+        .trim()
+        .notEmpty().withMessage('Vous devez préciser votre nom'),
+
+    body('first_name')
+        .trim()
+        .notEmpty().withMessage('Vous devez préciser votre prénom'),
+
+    body('email')
+        .trim()
+        .notEmpty().withMessage('Vous devez préciser votre courriel')
+        .isEmail().withMessage('Ce courriel n\'est pas valide')
+        .normalizeEmail()
+        .if((value, { req }) => req.body.is_actor === true && req.body.request_type.includes('access-request'))
+        .custom(async (value, { req }) => {
+            let user = null;
+            try {
+                user = await userModel.findOneByEmail(value);
+            } catch (error) {
+                throw new Error('Une erreur est survenue lors de la vérification de votre courriel');
+            }
+
+            if (user !== null) {
+                throw new Error('Un utilisateur existe déjà pour ce courriel');
+            }
+
+            req.body.user_full = user;
+            return true;
+        }),
+
+    body('request_type')
+        .isArray({ min: 1 }).withMessage('Vous devez préciser la ou les raisons de votre prise de contact')
+        .custom((requestTypes) => {
+            if (!Array.isArray(requestTypes)) {
+                return true;
+            }
+
+            const improperValues = requestTypes.filter(type => !ALLOWED_TYPES.includes(type));
+            if (improperValues.length > 0) {
+                throw new Error('Certaines raisons sélectionnées ne sont pas reconnues');
+            }
+
+            return true;
+        }),
+
+    body('is_actor')
+        .isBoolean().withMessage('Vous devez préciser si vous êtes un acteur de la résorption des bidonvilles'),
+
+    body('organization_category')
+        .if((value, { req }) => req.body.is_actor === true && req.body.request_type.includes('access-request'))
+        .custom(async (value, { req }) => {
+            if (!value) {
+                throw new Error('Vous devez préciser votre structure');
+            }
+
+            let organizationCategory;
+            try {
+                organizationCategory = await organizationCategoryModel.findOneById(value);
+            } catch (error) {
+                throw new Error('Une erreur est survenue lors de la vérification de votre structure');
+            }
+
+            if (organizationCategory === null) {
+                throw new Error('La structure que vous avez sélectionnée n\'existe pas en base de données');
+            }
+
+            req.body.organization_category_full = organizationCategory;
+            return true;
+        }),
+
+    body('organization_type')
+        .if((value, { req }) => req.body.organization_category_full.uid === 'public_establishment')
+        .custom(async (value, { req }) => {
+            if (!value) {
+                throw new Error('Vous devez préciser le type de votre structure');
+            }
+
+            let organizationType;
+            try {
+                organizationType = await organizationTypeModel.findOneById(value);
+            } catch (error) {
+                throw new Error('Une erreur est survenue lors de la vérification de votre type de structure');
+            }
+
+            if (organizationType === null) {
+                throw new Error('Le type de structure que vous avez sélectionné n\'existe pas en base de données');
+            }
+
+            if (organizationType.organization_category !== 'public_establishment') {
+                throw new Error('Le type de structure que vous avez sélectionné est invalide');
+            }
+
+            req.body.organization_type_full = organizationType;
+            return true;
+        }),
+
+    body('organization_public')
+        .if((value, { req }) => req.body.organization_type_full !== undefined)
+        .custom(async (value, { req }) => {
+            if (!value) {
+                throw new Error('Vous devez préciser le territoire de rattachement de votre structure');
+            }
+
+            let organization;
+            try {
+                organization = await organizationModel.findOneById(value);
+            } catch (error) {
+                throw new Error('Une erreur est survenue lors de la vérification de votre territoire de rattachement');
+            }
+
+            if (organization === null) {
+                throw new Error('Le territoire de rattachement que vous avez sélectionné n\'existe pas en base de données');
+            }
+
+            if (organization.fk_type !== req.body.organization_type) {
+                throw new Error('Le territoire de rattachement que vous avez sélectionné est invalide');
+            }
+
+            req.body.organization_full = organization;
+            return true;
+        }),
+
+    body('territorial_collectivity')
+        .if((value, { req }) => req.body.organization_category_full.uid === 'territorial_collectivity')
+        .custom(async (value, { req }) => {
+            if (!value) {
+                throw new Error('Vous devez préciser le nom de votre structure');
+            }
+
+            let organization;
+            try {
+                organization = await organizationModel.findOneByLocation(
+                    value.category,
+                    value.data.type,
+                    value.data.code,
+                );
+            } catch (error) {
+                throw new Error('Une erreur est survenue lors de la vérification du nom de votre structure');
+            }
+
+            if (organization === null) {
+                throw new Error('Le nom de structure que vous avez sélectionné n\'existe pas en base de données');
+            }
+
+            if (organization.fk_category !== 'territorial_collectivity') {
+                throw new Error('Le nom de structure que vous avez sélectionné est invalide');
+            }
+
+            req.body.organization_full = organization;
+            return true;
+        }),
+
+    body('organization_administration')
+        .if((value, { req }) => req.body.organization_category_full.uid === 'administration')
+        .custom(async (value, { req }) => {
+            if (!value) {
+                throw new Error('Vous devez préciser le nom de votre structure');
+            }
+
+            let organization;
+            try {
+                organization = await organizationModel.findOneById(value);
+            } catch (error) {
+                throw new Error('Une erreur est survenue lors de la vérification du nom de votre structure');
+            }
+
+            if (organization === null) {
+                throw new Error('Le nom de structure que vous avez sélectionné n\'existe pas en base de données');
+            }
+
+            if (organization.fk_category !== 'administration') {
+                throw new Error('Le nom de structure que vous avez sélectionné est invalide');
+            }
+
+            req.body.organization_full = organization;
+            return true;
+        }),
+
+    body('association')
+        .if((value, { req }) => req.body.organization_category_full.uid === 'association')
+        .custom(async (value) => {
+            if (!value) {
+                throw new Error('Vous devez préciser le nom de votre structure');
+            }
+
+            if (value === 'Autre') {
+                return true;
+            }
+
+            let organization;
+            try {
+                organization = await organizationModel.findAssociationName(value);
+            } catch (error) {
+                throw new Error('Une erreur est survenue lors de la vérification du nom de votre structure');
+            }
+
+            if (organization === null) {
+                throw new Error('Le nom de structure que vous avez sélectionné n\'existe pas en base de données');
+            }
+
+            return true;
+        }),
+
+    body('new_association_name')
+        .if((value, { req }) => req.body.organization_category_full.uid === 'association' && req.body.association === 'Autre')
+        .trim()
+        .custom(async (value) => {
+            if (!value) {
+                throw new Error('Vous devez préciser le nom complet de votre association');
+            }
+
+            let organization;
+            try {
+                organization = await organizationModel.findAssociationName(value);
+            } catch (error) {
+                throw new Error('Une erreur est survenue lors de la vérification du nom de votre structure');
+            }
+
+            if (organization !== null) {
+                throw new Error('Il existe déjà une association enregistrée sous ce nom');
+            }
+
+            return true;
+        }),
+
+    body('new_association_abbreviation')
+        .if((value, { req }) => req.body.organization_category_full.uid === 'association' && req.body.association === 'Autre')
+        .trim(),
+
+    body('departement')
+        .if((value, { req }) => req.body.organization_category_full.uid === 'association')
+        .custom(async (value, { req }) => {
+            if (!value) {
+                throw new Error('Vous devez préciser votre territoire de rattachement');
+            }
+
+            // case of an existing association
+            let association = null;
+            if (req.body.association !== 'Autre' && req.body.association) {
+                try {
+                    association = await organizationModel.findOneAssociation(
+                        req.body.association,
+                        value,
+                    );
+                } catch (error) {
+                    throw new Error('Une erreur est survenue lors de la vérification de votre territoire de rattachement');
+                }
+
+                if (association !== null) {
+                    req.body.organization_full = association;
+                    req.body.new_association = false;
+                    return true;
+                }
+            }
+
+            // case of a new association (brand new, or new departement)
+            let departement;
+            try {
+                departement = await departementModel.findOne(value);
+            } catch (error) {
+                throw new Error('Une erreur est survenue lors de la vérification de votre département');
+            }
+
+            if (departement === null) {
+                throw new Error('Le territoire de rattachement que vous avez sélectionné n\'existe pas en base de données');
+            }
+
+            req.body.new_association = true;
+            return true;
+        }),
+
+    body('position')
+        .if((value, { req }) => req.body.is_actor === true && req.body.request_type.includes('access-request'))
+        .trim()
+        .notEmpty().withMessage('Vous devez préciser votre fonction au sein de la structure'),
+
+    body('access_request_message')
+        .trim()
+        .notEmpty().withMessage('Vous devez préciser votre message'),
+
+    body('legal')
+        .custom((value) => {
+            if (value !== true) {
+                throw new Error('Vous devez certifier que ces données personnelles ont été saisies avec votre accord');
+            }
+
+            return true;
+        }),
+];

--- a/server/middlewares/validators/createContact.js
+++ b/server/middlewares/validators/createContact.js
@@ -1,6 +1,6 @@
 /* eslint-disable newline-per-chained-call */
 const { body } = require('express-validator');
-const newUser = require('./newUser');
+const newUser = require('./common/newUser');
 
 const ALLOWED_TYPES = require('#server/config/contact_request_types');
 

--- a/server/middlewares/validators/createUser.js
+++ b/server/middlewares/validators/createUser.js
@@ -1,0 +1,4 @@
+/* eslint-disable newline-per-chained-call */
+const newUser = require('./common/newUser');
+
+module.exports = newUser();

--- a/server/middlewares/validators/index.js
+++ b/server/middlewares/validators/index.js
@@ -1,5 +1,7 @@
 const createContact = require('./createContact');
+const createUser = require('./createUser');
 
 module.exports = {
     createContact,
+    createUser,
 };

--- a/server/middlewares/validators/index.js
+++ b/server/middlewares/validators/index.js
@@ -1,0 +1,5 @@
+const createContact = require('./createContact');
+
+module.exports = {
+    createContact,
+};

--- a/server/models/organizationModel.js
+++ b/server/models/organizationModel.js
@@ -137,6 +137,7 @@ module.exports = database => ({
             `SELECT
                 organizations.organization_id AS id,
                 organizations.name,
+                organizations.abbreviation,
                 organization_types.fk_category
             FROM localized_organizations AS organizations
             LEFT JOIN

--- a/server/models/shantytownModel.js
+++ b/server/models/shantytownModel.js
@@ -50,7 +50,7 @@ function getDiff(oldVersion, newVersion) {
     ];
 
     const labels = {
-        name: 'Nom',
+        name: 'Appellation du site',
         priority: 'Priorité',
         builtAt: 'Date d\'installation',
         declaredAt: 'Date de signalement',

--- a/server/models/shantytownModel.js
+++ b/server/models/shantytownModel.js
@@ -40,7 +40,7 @@ function fromGeoLevelToTableName(geoLevel) {
  */
 function getDiff(oldVersion, newVersion) {
     const properties = [
-        'name', 'priority', 'builtAt', 'declaredAt', 'addressSimple', /* 'latitude', 'longitude', */
+        'name', 'priority', 'builtAt', 'declaredAt', 'addressSimple',
         'addressDetails', 'fieldType', 'ownerType', 'owner', 'censusStatus', 'censusConductedAt',
         'censusConductedBy', 'populationTotal', 'populationCouples', 'populationMinors',
         'socialOrigins', 'electricityType', 'electricityComments', 'accessToSanitary', 'sanitaryComments', 'accessToWater', 'waterComments',

--- a/server/models/shantytownModel.js
+++ b/server/models/shantytownModel.js
@@ -40,7 +40,7 @@ function fromGeoLevelToTableName(geoLevel) {
  */
 function getDiff(oldVersion, newVersion) {
     const properties = [
-        'priority', 'builtAt', 'declaredAt', 'addressSimple', /* 'latitude', 'longitude', */
+        'name', 'priority', 'builtAt', 'declaredAt', 'addressSimple', /* 'latitude', 'longitude', */
         'addressDetails', 'fieldType', 'ownerType', 'owner', 'censusStatus', 'censusConductedAt',
         'censusConductedBy', 'populationTotal', 'populationCouples', 'populationMinors',
         'socialOrigins', 'electricityType', 'electricityComments', 'accessToSanitary', 'sanitaryComments', 'accessToWater', 'waterComments',
@@ -50,6 +50,7 @@ function getDiff(oldVersion, newVersion) {
     ];
 
     const labels = {
+        name: 'Nom',
         priority: 'Priorité',
         builtAt: 'Date d\'installation',
         declaredAt: 'Date de signalement',
@@ -252,6 +253,7 @@ function serializeComment(comment) {
 function serializeShantytown(town, permission) {
     const serializedTown = {
         id: town.id,
+        name: town.name,
         status: town.status,
         latitude: town.latitude,
         longitude: town.longitude,
@@ -355,6 +357,7 @@ function serializeShantytown(town, permission) {
 const SQL = {
     selection: {
         'shantytowns.shantytown_id': 'id',
+        'shantytowns.name': 'name',
         'shantytowns.priority': 'priority',
         'shantytowns.status': 'status',
         'shantytowns.declared_at': 'declaredAt',

--- a/server/models/shantytownModel.js
+++ b/server/models/shantytownModel.js
@@ -243,6 +243,43 @@ function serializeComment(comment) {
 }
 
 /**
+ * Computes the simplified address of the given shantytown
+ *
+ * @param {Object} shantytown
+ *
+ * @returns {String}
+ */
+function getAddressSimpleOf(shantytown) {
+    return shantytown.addressSimple || 'Pas d\'adresse précise';
+}
+
+/**
+ * Computes the usename of the given shantytown
+ *
+ * @param {Object} shantytown
+ *
+ * @returns {String}
+ */
+function getUsenameOf(shantytown) {
+    const addressSimple = getAddressSimpleOf(shantytown);
+
+    // process usename
+    if (shantytown.name) {
+        let aka;
+        if (!shantytown.addressSimple) {
+            aka = `site dit ${shantytown.name}`;
+        } else {
+            aka = shantytown.name;
+        }
+
+        return `${addressSimple} « ${aka} »`;
+    }
+
+    return addressSimple;
+}
+
+
+/**
  * Serializes a single shantytown row
  *
  * @param {Object} town
@@ -280,7 +317,8 @@ function serializeShantytown(town, permission) {
         closedAt: town.closedAt !== null ? (town.closedAt.getTime() / 1000) : null,
         address: town.address,
         addressDetails: town.addressDetails,
-        addressSimple: town.addressSimple || 'Pas d\'adresse précise',
+        addressSimple: getAddressSimpleOf(town),
+        usename: getUsenameOf(town),
         populationTotal: town.populationTotal,
         populationCouples: town.populationCouples,
         populationMinors: town.populationMinors,
@@ -910,7 +948,7 @@ module.exports = (database) => {
                         },
                         shantytown: {
                             id: activity.id,
-                            name: activity.addressSimple,
+                            usename: getUsenameOf(activity),
                             city: activity.cityName,
                             departement: activity.departement,
                         },
@@ -965,7 +1003,7 @@ module.exports = (database) => {
                     if (previousVersion === null) {
                         action = 'creation';
                     } else {
-                        o.shantytown.name = previousVersion.addressSimple;
+                        o.shantytown.usename = getUsenameOf(previousVersion);
 
                         if (previousVersion.closedAt === null && activity.closedAt !== null) {
                             action = 'closing';

--- a/server/models/userModel.js
+++ b/server/models/userModel.js
@@ -591,6 +591,8 @@ module.exports = (database) => {
             },
         ),
 
+        getNationalAdmins,
+
         getDirectory: async () => {
             const users = await database.query(
                 `

--- a/server/services/createUser.js
+++ b/server/services/createUser.js
@@ -1,0 +1,61 @@
+const { sequelize } = require('#db/models/index');
+const userModel = require('#server/models/userModel')(sequelize);
+const organizationModel = require('#server/models/organizationModel')(sequelize);
+const organizationTypeModel = require('#server/models/organizationTypeModel')(sequelize);
+const { generateSalt } = require('#server/utils/auth');
+
+async function createUser(data) {
+    const userId = await sequelize.transaction(async (t) => {
+        // create association if necessary
+        if (data.organization_category === 'association') {
+            let create = null;
+            let organization = null;
+            if (data.association === 'Autre') {
+                create = {
+                    name: data.newAssociationName,
+                    abbreviation: data.newAssociationAbbreviation || null,
+                };
+            } else {
+                organization = await organizationModel.findOneAssociation(
+                    data.association,
+                    data.departement,
+                );
+
+                if (organization === null) {
+                    const association = await organizationModel.findAssociationName(data.association);
+
+                    create = {
+                        name: association !== null ? association.name : data.association,
+                        abbreviation: association !== null ? association.abbreviation : null,
+                    };
+                }
+            }
+
+            if (create !== null) {
+                const type = (await organizationTypeModel.findByCategory('association'))[0].id;
+                [[organization]] = (await organizationModel.create(
+                    create.name,
+                    create.abbreviation,
+                    type,
+                    null,
+                    data.departement,
+                    null,
+                    null,
+                    false,
+                    t,
+                ));
+            }
+
+            Object.assign(data, { organization: organization.id });
+        }
+
+        // create the user himself
+        return userModel.create(Object.assign(data, {
+            salt: generateSalt(),
+        }), t);
+    });
+
+    return userModel.findOne(userId);
+}
+
+module.exports = createUser;

--- a/server/services/userService.js
+++ b/server/services/userService.js
@@ -1,65 +1,7 @@
-const { sequelize } = require('#db/models/index');
-const userModel = require('#server/models/userModel')(sequelize);
-const organizationModel = require('#server/models/organizationModel')(sequelize);
-const organizationTypeModel = require('#server/models/organizationTypeModel')(sequelize);
-const { generateSalt } = require('#server/utils/auth');
-
 const sanitize = require('#server/controllers/userController/helpers/sanitize');
 const validate = require('#server/controllers/userController/helpers/validate');
+const createUser = require('./createUser');
 
-async function createUser(data) {
-    const userId = await sequelize.transaction(async (t) => {
-        // create association if necessary
-        if (data.organization_category === 'association') {
-            let create = null;
-            let organization = null;
-            if (data.association === 'Autre') {
-                create = {
-                    name: data.newAssociationName,
-                    abbreviation: data.newAssociationAbbreviation || null,
-                };
-            } else {
-                organization = await organizationModel.findOneAssociation(
-                    data.association,
-                    data.departement,
-                );
-
-                if (organization === null) {
-                    const association = await organizationModel.findAssociationName(data.association);
-
-                    create = {
-                        name: association !== null ? association.name : data.association,
-                        abbreviation: association !== null ? association.abbreviation : null,
-                    };
-                }
-            }
-
-            if (create !== null) {
-                const type = (await organizationTypeModel.findByCategory('association'))[0].id;
-                [[organization]] = (await organizationModel.create(
-                    create.name,
-                    create.abbreviation,
-                    type,
-                    null,
-                    data.departement,
-                    null,
-                    null,
-                    false,
-                    t,
-                ));
-            }
-
-            Object.assign(data, { organization: organization.id });
-        }
-
-        // create the user himself
-        return userModel.create(Object.assign(data, {
-            salt: generateSalt(),
-        }), t);
-    });
-
-    return userModel.findOne(userId);
-}
 
 async function validateCreationInput(rawData, extendedFields = []) {
     // get the list of fields to be validated

--- a/server/services/userService.js
+++ b/server/services/userService.js
@@ -1,89 +1,10 @@
-const sanitize = require('#server/controllers/userController/helpers/sanitize');
-const validate = require('#server/controllers/userController/helpers/validate');
 const createUser = require('./createUser');
 
-
-async function validateCreationInput(rawData, extendedFields = []) {
-    // get the list of fields to be validated
-    const fields = [
-        ...[
-            { key: 'last_name', sanitizer: 'string' },
-            { key: 'first_name', sanitizer: 'string' },
-            { key: 'email', sanitizer: 'string' },
-            { key: 'organization_category', sanitizer: 'string' },
-            { key: 'position', sanitizer: 'string' },
-            { key: 'legal', sanitizer: 'bool' },
-        ],
-        ...extendedFields,
-    ];
-
-    const specificFields = {
-        public_establishment() {
-            return [
-                { key: 'organization_type', sanitizer: 'integer' },
-                { key: 'organization_public', sanitizer: 'integer' },
-            ];
-        },
-
-        territorial_collectivity() {
-            return [
-                { key: 'territorial_collectivity', sanitizer: 'object' },
-            ];
-        },
-
-        association() {
-            return [
-                { key: 'association', sanitizer: 'string' },
-                { key: 'newAssociationName', sanitizer: 'string' },
-                { key: 'newAssociationAbbreviation', sanitizer: 'string' },
-                { key: 'departement', sanitizer: 'string' },
-            ];
-        },
-
-        administration() {
-            return [
-                { key: 'organization_administration', sanitizer: 'integer' },
-            ];
-        },
-    };
-
-    if (Object.prototype.hasOwnProperty.call(specificFields, rawData.organization_category)) {
-        fields.push(...specificFields[rawData.organization_category]());
-    }
-
-    // sanitize
-    const sanitizedData = sanitize(rawData, fields);
-
-    // validate
-    return {
-        sanitizedData,
-        errors: await validate(sanitizedData, fields),
-    };
-}
-
 const userService = {};
-userService.create = async (data, extendedFields, createdBy = null) => {
-    // validate input
-    const { sanitizedData, errors } = await validateCreationInput(data, extendedFields);
-
-    if (Object.keys(errors).length > 0) {
-        return {
-            error: {
-                code: 400,
-                response: {
-                    error: {
-                        user_message: 'Certaines informations saisies sont incorrectes',
-                        developer_message: 'Input data is invalid',
-                        fields: errors,
-                    },
-                },
-            },
-        };
-    }
-
+userService.create = async (data, createdBy = null) => {
     // insert user into database
     try {
-        return await createUser(Object.assign({}, sanitizedData, {
+        return await createUser(Object.assign({}, data, {
             created_by: createdBy,
         }));
     } catch (error) {

--- a/server/services/userService.js
+++ b/server/services/userService.js
@@ -1,0 +1,162 @@
+const { sequelize } = require('#db/models/index');
+const userModel = require('#server/models/userModel')(sequelize);
+const organizationModel = require('#server/models/organizationModel')(sequelize);
+const organizationTypeModel = require('#server/models/organizationTypeModel')(sequelize);
+const { generateSalt } = require('#server/utils/auth');
+
+const sanitize = require('#server/controllers/userController/helpers/sanitize');
+const validate = require('#server/controllers/userController/helpers/validate');
+
+async function createUser(data) {
+    const userId = await sequelize.transaction(async (t) => {
+        // create association if necessary
+        if (data.organization_category === 'association') {
+            let create = null;
+            let organization = null;
+            if (data.association === 'Autre') {
+                create = {
+                    name: data.newAssociationName,
+                    abbreviation: data.newAssociationAbbreviation || null,
+                };
+            } else {
+                organization = await organizationModel.findOneAssociation(
+                    data.association,
+                    data.departement,
+                );
+
+                if (organization === null) {
+                    const association = await organizationModel.findAssociationName(data.association);
+
+                    create = {
+                        name: association !== null ? association.name : data.association,
+                        abbreviation: association !== null ? association.abbreviation : null,
+                    };
+                }
+            }
+
+            if (create !== null) {
+                const type = (await organizationTypeModel.findByCategory('association'))[0].id;
+                [[organization]] = (await organizationModel.create(
+                    create.name,
+                    create.abbreviation,
+                    type,
+                    null,
+                    data.departement,
+                    null,
+                    null,
+                    false,
+                    t,
+                ));
+            }
+
+            Object.assign(data, { organization: organization.id });
+        }
+
+        // create the user himself
+        return userModel.create(Object.assign(data, {
+            salt: generateSalt(),
+        }), t);
+    });
+
+    return userModel.findOne(userId);
+}
+
+async function validateCreationInput(rawData, extendedFields = []) {
+    // get the list of fields to be validated
+    const fields = [
+        ...[
+            { key: 'last_name', sanitizer: 'string' },
+            { key: 'first_name', sanitizer: 'string' },
+            { key: 'email', sanitizer: 'string' },
+            { key: 'organization_category', sanitizer: 'string' },
+            { key: 'position', sanitizer: 'string' },
+            { key: 'legal', sanitizer: 'bool' },
+        ],
+        ...extendedFields,
+    ];
+
+    const specificFields = {
+        public_establishment() {
+            return [
+                { key: 'organization_type', sanitizer: 'integer' },
+                { key: 'organization_public', sanitizer: 'integer' },
+            ];
+        },
+
+        territorial_collectivity() {
+            return [
+                { key: 'territorial_collectivity', sanitizer: 'object' },
+            ];
+        },
+
+        association() {
+            return [
+                { key: 'association', sanitizer: 'string' },
+                { key: 'newAssociationName', sanitizer: 'string' },
+                { key: 'newAssociationAbbreviation', sanitizer: 'string' },
+                { key: 'departement', sanitizer: 'string' },
+            ];
+        },
+
+        administration() {
+            return [
+                { key: 'organization_administration', sanitizer: 'integer' },
+            ];
+        },
+    };
+
+    if (Object.prototype.hasOwnProperty.call(specificFields, rawData.organization_category)) {
+        fields.push(...specificFields[rawData.organization_category]());
+    }
+
+    // sanitize
+    const sanitizedData = sanitize(rawData, fields);
+
+    // validate
+    return {
+        sanitizedData,
+        errors: await validate(sanitizedData, fields),
+    };
+}
+
+const userService = {};
+userService.create = async (data, extendedFields, createdBy = null) => {
+    // validate input
+    const { sanitizedData, errors } = await validateCreationInput(data, extendedFields);
+
+    if (Object.keys(errors).length > 0) {
+        return {
+            error: {
+                code: 400,
+                response: {
+                    error: {
+                        user_message: 'Certaines informations saisies sont incorrectes',
+                        developer_message: 'Input data is invalid',
+                        fields: errors,
+                    },
+                },
+            },
+        };
+    }
+
+    // insert user into database
+    try {
+        return await createUser(Object.assign({}, sanitizedData, {
+            created_by: createdBy,
+        }));
+    } catch (error) {
+        return {
+            error: {
+                code: 500,
+                response: {
+                    error: {
+                        user_message: 'Une erreur est survenue lors de l\'écriture en base de données',
+                        developer_message: 'Failed inserting the new user into database',
+                    },
+                },
+            },
+        };
+    }
+};
+
+module.exports = userService;

--- a/test/suites/server/controllers/contactController/contact.spec.js
+++ b/test/suites/server/controllers/contactController/contact.spec.js
@@ -1,0 +1,418 @@
+/* eslint-disable global-require */
+
+/* **************************************************************************************************
+ * TOOLS
+ * *********************************************************************************************** */
+
+const chai = require('chai');
+const sinon = require('sinon');
+chai.use(require('sinon-chai'));
+const rewiremock = require('rewiremock/node');
+
+const { expect } = require('chai');
+const { mockRes } = require('sinon-express-mock');
+
+
+function generateFakeUser() {
+    return {
+        id: global.generate('number'),
+        email: global.generate('string'),
+        departement: global.generate('string'),
+        map_center: [global.generate('number'), global.generate('number')],
+        first_name: global.generate('string'),
+        last_name: global.generate('string'),
+        company: global.generate('string'),
+        permissions: {
+            feature: [
+                global.generate('string'),
+                global.generate('string'),
+            ],
+            data: [
+                global.generate('string'),
+                global.generate('string'),
+            ],
+        },
+        default_export: [
+            global.generate('string'),
+            global.generate('string'),
+            global.generate('string'),
+        ],
+    };
+}
+
+
+/* **************************************************************************************************
+ * FIXTURES
+ * *********************************************************************************************** */
+
+
+const emailStub = sinon.stub();
+
+
+const mockModels = {
+    '#server/utils/mail': {
+        send: emailStub,
+    },
+};
+
+
+const controllerMockModels = {
+    user: {
+        getNationalAdmins: sinon.stub(),
+        findOne: sinon.stub(),
+        getAdminsFor: sinon.stub(),
+    },
+};
+
+
+/* **************************************************************************************************
+ * TESTS
+ * *********************************************************************************************** */
+
+describe.only('contactController.contact()', () => {
+    const req = {};
+    let res;
+
+    const user = generateFakeUser();
+
+    const nationalAdmins = [
+        generateFakeUser(),
+        generateFakeUser(),
+    ];
+
+    const regionalAdmins = [
+        generateFakeUser(),
+        generateFakeUser(),
+        generateFakeUser(),
+    ];
+
+    controllerMockModels.user.getNationalAdmins.resolves(nationalAdmins);
+    controllerMockModels.user.findOne.resolves(user);
+    controllerMockModels.user.getAdminsFor.resolves(regionalAdmins);
+
+    beforeEach(() => {
+        emailStub.reset();
+    });
+
+    describe('Success cases', () => {
+        it('Should handle a simple message', async () => {
+            const controller = rewiremock.proxy('#server/controllers/contactController', mockModels)(controllerMockModels);
+
+            req.body = {
+                access_request_message: 'ceci est un message',
+                email: 'gael.destrem@gmail.com',
+                first_name: 'gael',
+                last_name: 'destrem',
+                legal: true,
+                request_type: ['help'],
+            };
+            res = mockRes();
+
+            await controller.contact(req, res);
+
+            // It should send a message to all national admins and ensure that it returns a 200
+            expect(res.status).to.have.been.calledOnceWith(200);
+            expect(emailStub).to.have.been.callCount(nationalAdmins.length);
+        });
+
+        it('Should should handle an access request for a non actor', async () => {
+            const controller = rewiremock.proxy('#server/controllers/contactController', mockModels)(controllerMockModels);
+
+            req.body = {
+                access_request_message: 'ceci est un message',
+                email: 'gael.destrem@gmail.com',
+                first_name: 'gael',
+                last_name: 'destrem',
+                legal: true,
+                request_type: ['access-request'],
+                is_actor: false,
+            };
+            res = mockRes();
+
+            await controller.contact(req, res);
+
+            // It should send a message to all national admins and ensure that it returns a 200
+            expect(res.status).to.have.been.calledOnceWith(200);
+            expect(emailStub).to.have.been.callCount(nationalAdmins.length);
+        });
+
+        it('Should should handle an access request for a public_establishment', async () => {
+            const createUserStub = sinon.stub();
+            createUserStub.returns({});
+            const controller = rewiremock.proxy('#server/controllers/contactController', {
+                // Fake userService db models calls
+                '#server/models/userModel': module.exports = () => ({
+                    findOneByEmail: () => null,
+                }),
+                '#server/models/organizationCategoryModel': module.exports = () => ({
+                    findOneById: () => 'something',
+                }),
+                '#server/models/organizationTypeModel': module.exports = () => ({
+                    findOneById: () => ({ organization_category: 'public_establishment' }),
+                }),
+                '#server/models/organizationModel': module.exports = () => ({
+                    findOneById: () => ({ fk_type: 12 }),
+                }),
+                '#server/services/createUser': module.exports = createUserStub,
+            })(controllerMockModels);
+
+            req.body = {
+                access_request_message: "ceci est une demande d'acces",
+                email: 'gael.destrem@gmail.com',
+                first_name: 'gael',
+                last_name: 'destrem',
+                legal: true,
+                request_type: ['access-request'],
+                is_actor: true,
+                organization_category: 'public_establishment',
+                organization_public: '40765',
+                organization_type: '12',
+                position: 'test',
+            };
+            res = mockRes();
+
+            await controller.contact(req, res);
+
+            // It should send a message to all admins and ensure that it returns a 200
+            expect(createUserStub).to.have.been.calledOnceWith({
+                access_request_message: "ceci est une demande d'acces",
+                created_by: null,
+                email: 'gael.destrem@gmail.com',
+                first_name: 'gael',
+                last_name: 'destrem',
+                legal: true,
+                organization: undefined,
+                organization_category: 'public_establishment',
+                organization_public: 40765,
+                organization_type: 12,
+                position: 'test',
+            });
+            expect(res.status).to.have.been.calledOnceWith(200);
+        });
+
+        it('Should should handle an access request for a territorial_collectivity', async () => {
+            const createUserStub = sinon.stub();
+            createUserStub.returns({});
+            const controller = rewiremock.proxy('#server/controllers/contactController', {
+                // Fake userService db models calls
+                '#server/models/userModel': module.exports = () => ({
+                    findOneByEmail: () => null,
+                }),
+                '#server/models/organizationCategoryModel': module.exports = () => ({
+                    findOneById: () => 'something',
+                }),
+                '#server/models/organizationModel': module.exports = () => ({
+                    findOneById: () => ({ organization_category: 'territorial_collectivity' }),
+                    findOneByLocation: () => ({ fk_category: 'territorial_collectivity' }),
+                }),
+                '#server/services/createUser': module.exports = createUserStub,
+            })(controllerMockModels);
+
+            req.body = {
+                access_request_message: "ceci est une demande d'acces",
+                email: 'gael.destrem@gmail.com',
+                first_name: 'gael',
+                last_name: 'destrem',
+                legal: true,
+                request_type: ['access-request'],
+                is_actor: true,
+                organization_category: 'territorial_collectivity',
+                territorial_collectivity: {
+                    category: 'Commune',
+                    data: { code: '40101', type: 'city' },
+                    code: '40101',
+                    type: 'city',
+                    id: '40101',
+                    label: '(40) Gaas',
+                },
+                position: 'test',
+            };
+            res = mockRes();
+
+            await controller.contact(req, res);
+
+            // It should send a message to all admins and ensure that it returns a 200
+            expect(createUserStub).to.have.been.calledOnceWith({
+                access_request_message: "ceci est une demande d'acces",
+                created_by: null,
+                email: 'gael.destrem@gmail.com',
+                first_name: 'gael',
+                last_name: 'destrem',
+                legal: true,
+                organization: undefined,
+                organization_category: 'territorial_collectivity',
+                position: 'test',
+                territorial_collectivity: {
+                    category: 'Commune',
+                    code: '40101',
+                    data: { code: '40101', type: 'city' },
+                    id: '40101',
+                    label: '(40) Gaas',
+                    type: 'city',
+                },
+            });
+            expect(res.status).to.have.been.calledOnceWith(200);
+        });
+
+        it('Should should handle an access request for a administration', async () => {
+            const createUserStub = sinon.stub();
+            createUserStub.returns({});
+            const controller = rewiremock.proxy('#server/controllers/contactController', {
+                // Fake userService db models calls
+                '#server/models/userModel': module.exports = () => ({
+                    findOneByEmail: () => null,
+                }),
+                '#server/models/organizationCategoryModel': module.exports = () => ({
+                    findOneById: () => 'something',
+                }),
+                '#server/models/organizationModel': module.exports = () => ({
+                    findOneById: () => ({ fk_category: 'administration' }),
+                }),
+                '#server/services/createUser': module.exports = createUserStub,
+            })(controllerMockModels);
+
+            req.body = {
+                access_request_message: "ceci est une demande d'acces",
+                email: 'gael.destrem@gmail.com',
+                first_name: 'gael',
+                last_name: 'destrem',
+                legal: true,
+                request_type: ['access-request'],
+                is_actor: true,
+                organization_category: 'administration',
+                organization_administration: '40752',
+                position: 'rte',
+            };
+            res = mockRes();
+
+            await controller.contact(req, res);
+
+            // It should send a message to all admins and ensure that it returns a 200
+            expect(res.status).to.have.been.calledOnceWith(200);
+            expect(createUserStub).to.have.been.calledOnceWith({
+                access_request_message: "ceci est une demande d'acces",
+                created_by: null,
+                email: 'gael.destrem@gmail.com',
+                first_name: 'gael',
+                last_name: 'destrem',
+                legal: true,
+                organization: undefined,
+                organization_administration: 40752,
+                organization_category: 'administration',
+                position: 'rte',
+            });
+        });
+
+        it('Should should handle an access request for an existing association', async () => {
+            const createUserStub = sinon.stub();
+            createUserStub.returns({});
+            const controller = rewiremock.proxy('#server/controllers/contactController', {
+                // Fake userService db models calls
+                '#server/models/userModel': module.exports = () => ({
+                    findOneByEmail: () => null,
+                }),
+                '#server/models/organizationCategoryModel': module.exports = () => ({
+                    findOneById: () => 'something',
+                }),
+                '#server/models/organizationModel': module.exports = () => ({
+                    findAssociationName: () => 'something',
+                }),
+                '#server/models/departementModel': module.exports = () => ({
+                    findOne: () => 'something',
+                }),
+                '#server/services/createUser': module.exports = createUserStub,
+            })(controllerMockModels);
+
+            req.body = {
+                access_request_message: "ceci est une demande d'acces",
+                email: 'gael.destrem@gmail.com',
+                first_name: 'gael',
+                last_name: 'destrem',
+                legal: true,
+                request_type: ['access-request'],
+                is_actor: true,
+                organization_category: 'association',
+                association: 'Accueuil coopération insertion pour les nouveaux arrivants',
+                departement: '04',
+                position: 'test',
+            };
+            res = mockRes();
+
+            await controller.contact(req, res);
+
+            // It should send a message to all admins and ensure that it returns a 200
+            expect(res.status).to.have.been.calledOnceWith(200);
+            expect(createUserStub).to.have.been.calledOnceWith({
+                access_request_message: "ceci est une demande d'acces",
+                association: 'Accueuil coopération insertion pour les nouveaux arrivants',
+                created_by: null,
+                departement: '04',
+                email: 'gael.destrem@gmail.com',
+                first_name: 'gael',
+                last_name: 'destrem',
+                legal: true,
+                newAssociationAbbreviation: null,
+                newAssociationName: null,
+                organization_category: 'association',
+                position: 'test',
+            });
+        });
+
+        it('Should should handle an access request for a new association', async () => {
+            const createUserStub = sinon.stub();
+            createUserStub.returns({});
+            const controller = rewiremock.proxy('#server/controllers/contactController', {
+                // Fake userService db models calls
+                '#server/models/userModel': module.exports = () => ({
+                    findOneByEmail: () => null,
+                }),
+                '#server/models/organizationCategoryModel': module.exports = () => ({
+                    findOneById: () => 'something',
+                }),
+                '#server/models/organizationModel': module.exports = () => ({
+                    findAssociationName: () => null,
+                }),
+                '#server/models/departementModel': module.exports = () => ({
+                    findOne: () => 'something',
+                }),
+                '#server/services/createUser': module.exports = createUserStub,
+            })(controllerMockModels);
+
+            req.body = {
+                access_request_message: "ceci est une demande d'acces",
+                email: 'gael.destrem@gmail.com',
+                first_name: 'gael',
+                last_name: 'destrem',
+                legal: true,
+                request_type: ['access-request'],
+                is_actor: true,
+                organization_category: 'association',
+                association: 'Autre',
+                newAssociationName: 'Nouvelle asso',
+                newAssociationAbbreviation: 'Nouvelle asso abbreviation',
+                departement: '04',
+                position: 'test',
+            };
+            res = mockRes();
+
+            await controller.contact(req, res);
+
+            // It should send a message to all admins and ensure that it returns a 200
+            expect(res.status).to.have.been.calledOnceWith(200);
+            expect(createUserStub).to.have.been.calledOnceWith({
+                access_request_message: "ceci est une demande d'acces",
+                association: 'Autre',
+                created_by: null,
+                departement: '04',
+                email: 'gael.destrem@gmail.com',
+                first_name: 'gael',
+                last_name: 'destrem',
+                legal: true,
+                newAssociationName: 'Nouvelle asso',
+                newAssociationAbbreviation: 'Nouvelle asso abbreviation',
+                organization_category: 'association',
+                position: 'test',
+            });
+        });
+    });
+});

--- a/test/suites/server/controllers/contactController/contact.spec.js
+++ b/test/suites/server/controllers/contactController/contact.spec.js
@@ -157,17 +157,22 @@ describe.only('contactController.contact()', () => {
             })(controllerMockModels);
 
             req.body = {
-                access_request_message: "ceci est une demande d'acces",
-                email: 'gael.destrem@gmail.com',
-                first_name: 'gael',
-                last_name: 'destrem',
-                legal: true,
                 request_type: ['access-request'],
                 is_actor: true,
+                access_request_message: "ceci est une demande d'acces",
+                last_name: 'destrem',
+                first_name: 'gael',
+                email: 'gael.destrem@gmail.com',
                 organization_category: 'public_establishment',
-                organization_public: '40765',
+                organization_category_full: {},
                 organization_type: '12',
+                organization_type_full: {},
+                organization_public: '40765',
+                organization_full: {
+                    id: 92,
+                },
                 position: 'test',
+                legal: true,
             };
             res = mockRes();
 
@@ -175,17 +180,17 @@ describe.only('contactController.contact()', () => {
 
             // It should send a message to all admins and ensure that it returns a 200
             expect(createUserStub).to.have.been.calledOnceWith({
+                last_name: 'destrem',
+                first_name: 'gael',
+                email: 'gael.destrem@gmail.com',
+                organization: 92,
+                new_association: false,
+                new_association_name: null,
+                new_association_abbreviation: null,
+                departement: null,
+                position: 'test',
                 access_request_message: "ceci est une demande d'acces",
                 created_by: null,
-                email: 'gael.destrem@gmail.com',
-                first_name: 'gael',
-                last_name: 'destrem',
-                legal: true,
-                organization: undefined,
-                organization_category: 'public_establishment',
-                organization_public: 40765,
-                organization_type: 12,
-                position: 'test',
             });
             expect(res.status).to.have.been.calledOnceWith(200);
         });
@@ -209,13 +214,12 @@ describe.only('contactController.contact()', () => {
             })(controllerMockModels);
 
             req.body = {
-                access_request_message: "ceci est une demande d'acces",
-                email: 'gael.destrem@gmail.com',
-                first_name: 'gael',
-                last_name: 'destrem',
-                legal: true,
                 request_type: ['access-request'],
                 is_actor: true,
+                access_request_message: "ceci est une demande d'acces",
+                last_name: 'destrem',
+                first_name: 'gael',
+                email: 'gael.destrem@gmail.com',
                 organization_category: 'territorial_collectivity',
                 territorial_collectivity: {
                     category: 'Commune',
@@ -225,7 +229,11 @@ describe.only('contactController.contact()', () => {
                     id: '40101',
                     label: '(40) Gaas',
                 },
+                organization_full: {
+                    id: 92,
+                },
                 position: 'test',
+                legal: true,
             };
             res = mockRes();
 
@@ -233,23 +241,17 @@ describe.only('contactController.contact()', () => {
 
             // It should send a message to all admins and ensure that it returns a 200
             expect(createUserStub).to.have.been.calledOnceWith({
+                last_name: 'destrem',
+                first_name: 'gael',
+                email: 'gael.destrem@gmail.com',
+                organization: 92,
+                new_association: false,
+                new_association_name: null,
+                new_association_abbreviation: null,
+                departement: null,
+                position: 'test',
                 access_request_message: "ceci est une demande d'acces",
                 created_by: null,
-                email: 'gael.destrem@gmail.com',
-                first_name: 'gael',
-                last_name: 'destrem',
-                legal: true,
-                organization: undefined,
-                organization_category: 'territorial_collectivity',
-                position: 'test',
-                territorial_collectivity: {
-                    category: 'Commune',
-                    code: '40101',
-                    data: { code: '40101', type: 'city' },
-                    id: '40101',
-                    label: '(40) Gaas',
-                    type: 'city',
-                },
             });
             expect(res.status).to.have.been.calledOnceWith(200);
         });
@@ -272,16 +274,19 @@ describe.only('contactController.contact()', () => {
             })(controllerMockModels);
 
             req.body = {
-                access_request_message: "ceci est une demande d'acces",
-                email: 'gael.destrem@gmail.com',
-                first_name: 'gael',
-                last_name: 'destrem',
-                legal: true,
                 request_type: ['access-request'],
                 is_actor: true,
+                access_request_message: "ceci est une demande d'acces",
+                last_name: 'destrem',
+                first_name: 'gael',
+                email: 'gael.destrem@gmail.com',
                 organization_category: 'administration',
                 organization_administration: '40752',
+                organization_full: {
+                    id: 92,
+                },
                 position: 'rte',
+                legal: true,
             };
             res = mockRes();
 
@@ -290,16 +295,17 @@ describe.only('contactController.contact()', () => {
             // It should send a message to all admins and ensure that it returns a 200
             expect(res.status).to.have.been.calledOnceWith(200);
             expect(createUserStub).to.have.been.calledOnceWith({
+                last_name: 'destrem',
+                first_name: 'gael',
+                email: 'gael.destrem@gmail.com',
+                organization: 92,
+                new_association: false,
+                new_association_name: null,
+                new_association_abbreviation: null,
+                departement: null,
+                position: 'rte',
                 access_request_message: "ceci est une demande d'acces",
                 created_by: null,
-                email: 'gael.destrem@gmail.com',
-                first_name: 'gael',
-                last_name: 'destrem',
-                legal: true,
-                organization: undefined,
-                organization_administration: 40752,
-                organization_category: 'administration',
-                position: 'rte',
             });
         });
 
@@ -324,17 +330,23 @@ describe.only('contactController.contact()', () => {
             })(controllerMockModels);
 
             req.body = {
-                access_request_message: "ceci est une demande d'acces",
-                email: 'gael.destrem@gmail.com',
-                first_name: 'gael',
-                last_name: 'destrem',
-                legal: true,
                 request_type: ['access-request'],
                 is_actor: true,
+                access_request_message: "ceci est une demande d'acces",
+                last_name: 'destrem',
+                first_name: 'gael',
+                email: 'gael.destrem@gmail.com',
                 organization_category: 'association',
-                association: 'Accueuil coopération insertion pour les nouveaux arrivants',
-                departement: '04',
-                position: 'test',
+                association: 'Accueil coopération insertion pour les nouveaux arrivants',
+                association_name: 'Accueil coopération insertion pour les nouveaux arrivants',
+                association_abbreviation: 'ACINA',
+                departement: '92',
+                new_association: false,
+                organization_full: {
+                    id: 92,
+                },
+                position: 'rte',
+                legal: true,
             };
             res = mockRes();
 
@@ -343,18 +355,17 @@ describe.only('contactController.contact()', () => {
             // It should send a message to all admins and ensure that it returns a 200
             expect(res.status).to.have.been.calledOnceWith(200);
             expect(createUserStub).to.have.been.calledOnceWith({
-                access_request_message: "ceci est une demande d'acces",
-                association: 'Accueuil coopération insertion pour les nouveaux arrivants',
-                created_by: null,
-                departement: '04',
-                email: 'gael.destrem@gmail.com',
-                first_name: 'gael',
                 last_name: 'destrem',
-                legal: true,
-                newAssociationAbbreviation: null,
-                newAssociationName: null,
-                organization_category: 'association',
-                position: 'test',
+                first_name: 'gael',
+                email: 'gael.destrem@gmail.com',
+                organization: 92,
+                new_association: false,
+                new_association_name: null,
+                new_association_abbreviation: null,
+                departement: '92',
+                position: 'rte',
+                access_request_message: "ceci est une demande d'acces",
+                created_by: null,
             });
         });
 
@@ -379,19 +390,22 @@ describe.only('contactController.contact()', () => {
             })(controllerMockModels);
 
             req.body = {
-                access_request_message: "ceci est une demande d'acces",
-                email: 'gael.destrem@gmail.com',
-                first_name: 'gael',
-                last_name: 'destrem',
-                legal: true,
                 request_type: ['access-request'],
                 is_actor: true,
+                access_request_message: "ceci est une demande d'acces",
+                last_name: 'destrem',
+                first_name: 'gael',
+                email: 'gael.destrem@gmail.com',
                 organization_category: 'association',
-                association: 'Autre',
-                newAssociationName: 'Nouvelle asso',
-                newAssociationAbbreviation: 'Nouvelle asso abbreviation',
+                association: 'Accueil coopération insertion pour les nouveaux arrivants',
+                association_name: 'Accueil coopération insertion pour les nouveaux arrivants',
+                association_abbreviation: 'ACINA',
                 departement: '04',
-                position: 'test',
+                new_association: true,
+                new_association_name: 'Accueil coopération insertion pour les nouveaux arrivants',
+                new_association_abbreviation: 'ACINA',
+                position: 'rte',
+                legal: true,
             };
             res = mockRes();
 
@@ -400,18 +414,17 @@ describe.only('contactController.contact()', () => {
             // It should send a message to all admins and ensure that it returns a 200
             expect(res.status).to.have.been.calledOnceWith(200);
             expect(createUserStub).to.have.been.calledOnceWith({
-                access_request_message: "ceci est une demande d'acces",
-                association: 'Autre',
-                created_by: null,
-                departement: '04',
-                email: 'gael.destrem@gmail.com',
-                first_name: 'gael',
                 last_name: 'destrem',
-                legal: true,
-                newAssociationName: 'Nouvelle asso',
-                newAssociationAbbreviation: 'Nouvelle asso abbreviation',
-                organization_category: 'association',
-                position: 'test',
+                first_name: 'gael',
+                email: 'gael.destrem@gmail.com',
+                organization: null,
+                new_association: true,
+                new_association_name: 'Accueil coopération insertion pour les nouveaux arrivants',
+                new_association_abbreviation: 'ACINA',
+                departement: '04',
+                position: 'rte',
+                access_request_message: "ceci est une demande d'acces",
+                created_by: null,
             });
         });
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2059,6 +2059,14 @@ expand-range@^1.8.1:
   dependencies:
     fill-range "^2.1.0"
 
+express-validator@^6.6.1:
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/express-validator/-/express-validator-6.6.1.tgz#c53046f615d27fcb78be786e018dcd60bd9c6c5c"
+  integrity sha512-+MrZKJ3eGYXkNF9p9Zf7MS7NkPJFg9MDYATU5c80Cf4F62JdLBIjWxy6481tRC0y1NnC9cgOw8FuN364bWaGhA==
+  dependencies:
+    lodash "^4.17.19"
+    validator "^13.1.1"
+
 express@^4.16.4:
   version "4.17.1"
   resolved "https://registry.yarnpkg.com/express/-/express-4.17.1.tgz#4491fc38605cf51f8629d39c2b5d026f98a4c134"
@@ -6445,6 +6453,11 @@ validator@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/validator/-/validator-11.1.0.tgz#ac18cac42e0aa5902b603d7a5d9b7827e2346ac4"
   integrity sha512-qiQ5ktdO7CD6C/5/mYV4jku/7qnqzjrxb3C/Q5wR3vGGinHTgJZN/TdFT3ZX4vXhX2R1PXx42fB1cn5W+uJ4lg==
+
+validator@^13.1.1:
+  version "13.1.17"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-13.1.17.tgz#ad677736950adddd3c37209484a6b2e0966579ad"
+  integrity sha512-zL5QBoemJ3jYFb2/j38y7ljhwYGXVLUp8H6W1nVxadnAOvUOytec+L7BHh1oBQ82/TzWXHd+GSaxUWp4lROkLg==
 
 vary@^1, vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
Dans le cadre de la refonte de la landing page ( cf. https://github.com/MTES-MCT/action-bidonvilles/pull/14 ), apport des éléments suivants :

- création d'une nouvelle route `POST /contact` qui gère les demandes d'accès publiques (qui peut déboucher éventuellement sur la création d'un nouvel utilisateur)
- modification de la route `POST /users` pour ne prendre en compte que la création d'utilisateurs depuis l'administration
- création d'une nouvelle couche de services qui assure la logique de création d'utilisateurs
- création d'une nouvelle couche middleware basée sur `express-validator` pour assurer la validation et sanitization des données en entrée des routes `POST /contact` et `POST /users`