### PR TITLE
(615) Retrait de la normalisation des emails

### DIFF
--- a/server/middlewares/validators/common/newUser.js
+++ b/server/middlewares/validators/common/newUser.js
@@ -24,6 +24,14 @@ module.exports = (additionalValidators = [], isAUserCreationCallback = (() => tr
         .trim()
         .notEmpty().withMessage('Vous devez préciser le courriel')
         .isEmail().withMessage('Ce courriel n\'est pas valide')
+        .normalizeEmail({
+            gmail_remove_dots: false,
+            gmail_remove_subaddress: false,
+            gmail_convert_googlemaildotcom: false,
+            outlookdotcom_remove_subaddress: false,
+            yahoo_remove_subaddress: false,
+            icloud_remove_subaddress: false,
+        })
         .if(isAUserCreationCallback)
         .custom(async (value, { req }) => {
             let user = null;

--- a/server/middlewares/validators/common/newUser.js
+++ b/server/middlewares/validators/common/newUser.js
@@ -24,7 +24,6 @@ module.exports = (additionalValidators = [], isAUserCreationCallback = (() => tr
         .trim()
         .notEmpty().withMessage('Vous devez préciser le courriel')
         .isEmail().withMessage('Ce courriel n\'est pas valide')
-        .normalizeEmail()
         .if(isAUserCreationCallback)
         .custom(async (value, { req }) => {
             let user = null;


### PR DESCRIPTION
La normalisation causait une réécriture des emails de manière invalide (par exemple suppression d'un "point").

Ticket : https://trello.com/c/1XKcmywy/615-les-emails-de-nouveaux-utilisateurs-ne-sont-pas-enregistr%C3%A9es-correctement