### PR TITLE
(618) Ajout des coordonnées GPS sur l'export

### DIFF
--- a/server/controllers/townController.js
+++ b/server/controllers/townController.js
@@ -836,6 +836,11 @@ module.exports = (models) => {
                     data: ({ addressDetails }) => addressDetails,
                     width: COLUMN_WIDTHS.LARGE,
                 },
+                coordinates: {
+                    title: 'Coordonnées GPS',
+                    data: ({ latitude, longitude }) => `${latitude},${longitude}`,
+                    width: COLUMN_WIDTHS.SMALL,
+                },
                 name: {
                     title: 'Appellation du site',
                     data: ({ name }) => name,
@@ -1186,7 +1191,7 @@ module.exports = (models) => {
                 });
             }
 
-            sections.push({
+            const localizationSection = {
                 title: 'Localisation',
                 properties: [
                     properties.departement,
@@ -1195,16 +1200,19 @@ module.exports = (models) => {
                     properties.name,
                 ],
                 lastFrozen: true,
-            });
+            };
+            sections.push(localizationSection);
 
             if (options.indexOf('address_details') !== -1 && !closedTowns) {
-                sections.push({
-                    title: '',
-                    properties: [
-                        properties.addressDetails,
-                    ],
-                });
+                localizationSection.properties.push(properties.addressDetails);
             }
+
+            sections.push({
+                title: '',
+                properties: [
+                    properties.coordinates,
+                ],
+            });
 
             let section = {
                 title: 'Site',


### PR DESCRIPTION
#### 📄 Description rapide
Ajout des coordonnées GPS des sites dans le fichier d'export.

#### 🗄 Tickets
- [618](https://trello.com/c/tEdCs5gZ/701-tableau-de-l%C3%A9volution-de-la-d%C3%A9mographie)

#### 🔗 PR associées
- https://github.com/MTES-MCT/action-bidonvilles/pull/55