### PR TITLE
(828) Correction du bug de tracking des vues sur l'annuaire

### DIFF
--- a/server/controllers/statsController.js
+++ b/server/controllers/statsController.js
@@ -138,6 +138,7 @@ module.exports = models => ({
             await Stats_Directory_Views.create({
                 organization: organizationId,
                 viewed_by: req.user.id,
+                created_at: new Date(),
             });
         } catch (error) {
             return res.status(500).send({


### PR DESCRIPTION
Je pense que ce bug date de l'époque où l'on a mis à jour Sequelize (donc **très** vieux) : le champ created_at n'étant pas précisé explicitement au moment de l'insertion en base, la requête échouait.