### PR TITLE
Page "statistiques publiques" : changements graphiques + wording et calcul mises à jour

### DIFF
--- a/server/controllers/statsController.js
+++ b/server/controllers/statsController.js
@@ -23,7 +23,6 @@ module.exports = models => ({
             models.stats.numberOfActiveUsers(),
             models.stats.numberOfNewUsersPerMonth(),
             models.stats.numberOfCollaboratorAndAssociationUsers(),
-            models.stats.numberOfCollaboratorAndAssociationOrganizations(),
             models.stats.numberOfShantytownOperations(),
             Stats_Exports.count(),
             models.stats.numberOfComments(),

--- a/server/models/statsModel.js
+++ b/server/models/statsModel.js
@@ -67,7 +67,10 @@ module.exports = database => ({
         );
 
         const result = [];
-        for (let i = 1; i <= 6; i += 1) {
+        const startDate = new Date('2020-06-01');
+        const monthsDiff = (now.getMonth() - startDate.getMonth()) + (now.getFullYear() - startDate.getFullYear()) * 12;
+
+        for (let i = 1; i <= monthsDiff; i += 1) {
             const date = new Date(now.getFullYear(), now.getMonth() - i, 1);
             const row = rows.find(({ month }) => parseInt(month, 10) === date.getMonth() + 1);
             result.unshift({
@@ -82,6 +85,7 @@ module.exports = database => ({
     numberOfCollaboratorAndAssociationUsers: async () => {
         const rows = await database.query(
             `SELECT
+                organization_types.fk_category,
                 COUNT(*) AS total
             FROM users
             LEFT JOIN localized_organizations AS organizations ON users.fk_organization = organizations.organization_id
@@ -91,14 +95,17 @@ module.exports = database => ({
                 AND
                 organizations.active = TRUE
                 AND
-                organization_types.fk_category IN ('territorial_collectivity', 'association', 'public_establishment')
+                organization_types.fk_category IN ('territorial_collectivity', 'association', 'public_establishment', 'administration')
+            GROUP BY organization_types.fk_category    
             `,
             {
                 type: database.QueryTypes.SELECT,
             },
         );
 
-        return rows[0].total;
+        return rows.reduce((hash, row) => Object.assign({}, hash, {
+            [row.fk_category]: row.total,
+        }), {});
     },
 
     numberOfCollaboratorAndAssociationOrganizations: async () => {
@@ -114,7 +121,7 @@ module.exports = database => ({
                 AND
                 organizations.active = TRUE
                 AND
-                organization_types.fk_category IN ('territorial_collectivity', 'association', 'public_establishment')
+                organization_types.fk_category IN ('territorial_collectivity', 'association', 'public_establishment', 'administration')
             GROUP BY organization_types.fk_category`,
             {
                 type: database.QueryTypes.SELECT,


### PR DESCRIPTION
https://trello.com/c/CrJimT5r/673-page-statistiques-publiques-changements-graphiques-wording-et-calcul-mises-%C3%A0-jour

- Suppression du champ `numberOfCollaboratorAndAssociationOrganizations` qui n'est plus utilisé coté front
- Modifications des fonctions `numberOfCollaboratorAndAssociationUsers` / `numberOfCollaboratorAndAssociationOrganizations` pour inclure les administrations
- Modifications des fonctions `numberOfCollaboratorAndAssociationUsers` pour renvoyer une répartition par type et non un total
- Modification de `numberOfNewUsersPerMonth` pour démarrer à partir de juin 2020

Pr liée: https://github.com/MTES-MCT/action-bidonvilles/pull/83