### PR TITLE
Correction d'un bug sur les stats privés

### DIFF
--- a/server/controllers/statsController.js
+++ b/server/controllers/statsController.js
@@ -23,6 +23,7 @@ module.exports = models => ({
             models.stats.numberOfActiveUsers(),
             models.stats.numberOfNewUsersPerMonth(),
             models.stats.numberOfCollaboratorAndAssociationUsers(),
+            models.stats.numberOfCollaboratorAndAssociationOrganizations(),
             models.stats.numberOfShantytownOperations(),
             Stats_Exports.count(),
             models.stats.numberOfComments(),


### PR DESCRIPTION
Correction d'un bug sur les stats privés.

La source vient de la PR sur les stats publiques où une typo s'était glissé 😅  

 https://github.com/MTES-MCT/action-bidonvilles-api/pull/55/files#diff-a3fc0623b7444be1d51aa0ccdaf8af15d2d9aa7eb124b3d715ede23247b5b2d7L26