### PR TITLE
#patch (904) Extension des permissions epci/city à departement

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "chai-as-promised": "^7.1.1",
     "chai-http": "^4.2.1",
     "chai-subset": "^1.6.0",
+    "deepmerge": "^4.2.2",
     "eslint": "^5.10.0",
     "eslint-config-airbnb-base": "^13.1.0",
     "husky": "^1.2.0",

--- a/server/controllers/planController.js
+++ b/server/controllers/planController.js
@@ -464,6 +464,7 @@ module.exports = models => ({
             const plans = await models.plan.findAll(req.user);
             res.status(200).send(plans);
         } catch (error) {
+            console.log(error);
             res.status(500).send({
                 error: {
                     user_message: 'Une erreur est survenue lors de la récupération des données en base',
@@ -475,8 +476,18 @@ module.exports = models => ({
 
     async find(req, res) {
         try {
-            const plans = await models.plan.findOne(req.user, req.params.id);
-            res.status(200).send(plans);
+            const plan = await models.plan.findOne(req.user, req.params.id);
+
+            if (plan === null) {
+                res.status(404).send({
+                    error: {
+                        user_message: 'Le dispositif demandé n\'existe pas',
+                    },
+                });
+                return;
+            }
+
+            res.status(200).send(plan);
         } catch (error) {
             res.status(500).send({
                 error: {

--- a/server/controllers/planController.js
+++ b/server/controllers/planController.js
@@ -464,7 +464,6 @@ module.exports = models => ({
             const plans = await models.plan.findAll(req.user);
             res.status(200).send(plans);
         } catch (error) {
-            console.log(error);
             res.status(500).send({
                 error: {
                     user_message: 'Une erreur est survenue lors de la récupération des données en base',

--- a/server/controllers/townController.js
+++ b/server/controllers/townController.js
@@ -13,6 +13,7 @@ const { send: sendMail } = require('#server/utils/mail');
 const { triggerShantytownCloseAlert, triggerShantytownCreationAlert } = require('#server/utils/slack');
 const { slack: slackConfig } = require('#server/config');
 const COMMENT_DELETION_MAIL = require('#server/mails/comment_deletion.js');
+const { can } = require('#server/services/permissionService');
 
 function fromGeoLevelToTableName(geoLevel) {
     switch (geoLevel) {
@@ -708,20 +709,6 @@ module.exports = (models) => {
         },
 
         async export(req, res, next) {
-            function isLocationAllowed(user, location) {
-                if (user.permissions.shantytown.export.geographic_level === 'nation') {
-                    return true;
-                }
-
-                if (user.organization.location.type === 'nation') {
-                    return true;
-                }
-
-                return location[user.organization.location.type]
-                    && user.organization.location[user.organization.location.type]
-                    && user.organization.location[user.organization.location.type].code === location[user.organization.location.type].code;
-            }
-
             if (!Object.prototype.hasOwnProperty.call(req.query, 'locationType')
                 || !Object.prototype.hasOwnProperty.call(req.query, 'locationCode')) {
                 return res.status(400).send({
@@ -751,7 +738,7 @@ module.exports = (models) => {
                 next(error);
             }
 
-            if (!isLocationAllowed(req.user, location)) {
+            if (!can(req.user).do('export', 'shantytown').on(location)) {
                 return res.status(400).send({
                     success: false,
                     response: {

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -117,7 +117,7 @@ module.exports = models => ({
         }
     },
 
-    async signin(req, res) {
+    async signin(req, res, next) {
         const { email, password } = req.body;
 
         if (typeof email !== 'string') {
@@ -146,9 +146,20 @@ module.exports = models => ({
             });
         }
 
-        const user = await models.user.findOneByEmail(email, {
-            auth: true,
-        });
+        let user;
+        try {
+            user = await models.user.findOneByEmail(email, {
+                auth: true,
+            });
+        } catch (error) {
+            res.status(500).send({
+                success: false,
+                error: {
+                    user_message: 'Une erreur est survenue lors de la lecture en base de données',
+                },
+            });
+            return next(error);
+        }
 
         if (user === null) {
             return res.status(403).send({

--- a/server/models/shantytownModel.js
+++ b/server/models/shantytownModel.js
@@ -1,4 +1,6 @@
 const { fromTsToFormat } = require('#server/utils/date');
+const { where } = require('#server/services/permissionService');
+const { buildWhere } = require('#server/utils/sql');
 
 /**
  * Converts a date column to a timestamp
@@ -664,51 +666,30 @@ module.exports = (database) => {
      *
      * @returns {Array.<Object>}
      */
-    async function query(where = [], order = ['departements.code ASC', 'cities.name ASC'], user, feature, includeChangelog = false) {
-        const replacements = {};
+    async function query(whereConditions = [], order = ['departements.code ASC', 'cities.name ASC'], user, feature, includeChangelog = false) {
+        const { statement, replacement } = buildWhere('shantytowns', whereConditions);
 
-        const featureLevel = user.permissions.shantytown[feature].geographic_level;
-        const userLevel = user.organization.location.type;
-        if (featureLevel !== 'nation' && (featureLevel !== 'local' || userLevel !== 'nation')) {
-            const level = featureLevel === 'local' ? userLevel : featureLevel;
-            if (user.organization.location[level] === null) {
-                return [];
+        try {
+            const permissionFilter = where().can(user).do(feature, 'shantytown');
+
+            if (permissionFilter !== null) {
+                statement.push(`(${permissionFilter.statement})`);
+                Object.assign(replacement, permissionFilter.replacements);
             }
-
-            const clauseGroup = {
-                location: {
-                    query: `${fromGeoLevelToTableName(level)}.code`,
-                    value: user.organization.location[level].code,
-                },
-            };
-            where.push(clauseGroup);
-
-            if (level === 'city') {
-                clauseGroup.location_main_city = {
-                    query: `${fromGeoLevelToTableName(level)}.fk_main`,
-                    value: user.organization.location[level].code,
-                };
-            }
+        } catch (error) {
+            // une erreur doit signifier que l'utilisateur n'a pas les permissions nécessaires, donc on retourne un tableau vide
+            return [];
         }
-
-        const whereClause = where.map((clauses, index) => {
-            const clauseGroup = Object.keys(clauses).map((column) => {
-                replacements[`${column}${index}`] = clauses[column].value || clauses[column];
-                return `${clauses[column].query || `shantytowns.${column}`} ${clauses[column].not ? 'NOT ' : ''}IN (:${column}${index})`;
-            }).join(' OR ');
-
-            return `(${clauseGroup})`;
-        }).join(' AND ');
 
         const towns = await database.query(
             getBaseSql(
                 'shantytowns',
-                where.length > 0 ? whereClause : null,
+                statement.length > 0 ? statement.join(' AND ') : null,
                 order.join(', '),
             ),
             {
                 type: database.QueryTypes.SELECT,
-                replacements,
+                replacements: replacement,
             },
         );
 
@@ -735,12 +716,12 @@ module.exports = (database) => {
                 database.query(
                     getBaseSql(
                         'ShantytownHistories',
-                        where.length > 0 ? whereClause : null,
+                        statement.length > 0 ? statement.join(' AND ') : null,
                         ['shantytowns.shantytown_id ASC', 'shantytowns."archivedAt" ASC'].join(', '),
                     ),
                     {
                         type: database.QueryTypes.SELECT,
-                        replacements,
+                        replacements: replacement,
                     },
                 ),
             );
@@ -938,12 +919,12 @@ module.exports = (database) => {
 
         getHistory: async (user, permission) => {
             // apply geographic level permission
-            const where = [];
+            const whereArr = [];
             const highCovidWhere = [];
             const replacements = {};
             if (user.permissions[permission.entity][permission.feature].geographic_level !== 'nation'
                 && user.organization.location.type !== 'nation') {
-                where.push(`${fromGeoLevelToTableName(user.organization.location.type)}.code = :locationCode`);
+                whereArr.push(`${fromGeoLevelToTableName(user.organization.location.type)}.code = :locationCode`);
                 highCovidWhere.push('d2.code = :locationCode');
                 replacements.locationCode = user.organization.location[user.organization.location.type].code;
             }
@@ -986,7 +967,7 @@ module.exports = (database) => {
                         LEFT JOIN shantytowns AS s ON shantytowns.shantytown_id = s.shantytown_id
                         ${SQL.joins.map(({ table, on }) => `LEFT JOIN ${table} ON ${on}`).join('\n')}
                         WHERE s.shantytown_id IS NOT NULL /* filter out history of deleted shantytowns */
-                        ${where.length > 0 ? `AND (${where.join(') AND (')})` : ''}
+                        ${whereArr.length > 0 ? `AND (${whereArr.join(') AND (')})` : ''}
                     )
                     UNION
                     (
@@ -1013,7 +994,7 @@ module.exports = (database) => {
                             NULL AS "highCommentDptCode"
                         FROM shantytowns
                         ${SQL.joins.map(({ table, on }) => `LEFT JOIN ${table} ON ${on}`).join('\n')}
-                        ${where.length > 0 ? `WHERE (${where.join(') AND (')})` : ''}
+                        ${whereArr.length > 0 ? `WHERE (${whereArr.join(') AND (')})` : ''}
                     )
                     UNION
                     (
@@ -1046,7 +1027,7 @@ module.exports = (database) => {
                         LEFT JOIN shantytown_covid_comments covid_comments ON covid_comments.fk_comment = comments.shantytown_comment_id
                         ${SQL.joins.map(({ table, on }) => `LEFT JOIN ${table} ON ${on}`).join('\n')}
                         WHERE shantytowns.shantytown_id IS NOT NULL /* filter out history of deleted shantytowns */
-                        ${where.length > 0 ? `AND (${where.join(') AND (')})` : ''}
+                        ${whereArr.length > 0 ? `AND (${whereArr.join(') AND (')})` : ''}
                     )
                     UNION
                     (

--- a/server/models/userModel.js
+++ b/server/models/userModel.js
@@ -1,5 +1,7 @@
 const permissionsDescription = require('#server/permissions_description');
 const { getPermissionsFor } = require('#server/utils/permission');
+const { where } = require('#server/services/permissionService');
+const { buildWhere } = require('#server/utils/sql');
 
 /**
  * @typedef {Object} UserFilters
@@ -86,6 +88,7 @@ function serializeUser(user, latestCharte, filters, permissionMap) {
                 city: user.city_code !== null ? {
                     code: user.city_code,
                     name: user.city_name,
+                    main: user.city_main,
                 } : null,
             },
         },
@@ -158,46 +161,29 @@ module.exports = (database) => {
     /**
      * Fetches a list of shantytowns from the database
      *
-     * @param {Array.<Object>} where   List of where clauses
+     * @param {Array.<Object>} whereConditions List of where clauses
      * @param {UserFilters}    filters
-     * @param {User}           [user]    The user's permissions are used for filtering the results of the query
-     * @param {String}         [feature] Permissions to be checked (necessary only if a user is provided)
+     * @param {User}           [user]          The user's permissions are used for filtering the results of the query
+     * @param {String}         [feature]       Permissions to be checked (necessary only if a user is provided)
      *
      * @returns {Array.<Object>}
      */
-    async function query(where = [], filters, user = null, feature) {
-        const replacements = {};
+    async function query(whereConditions = [], filters, user = null, feature) {
+        const { statement, replacement } = buildWhere('users', whereConditions);
 
         if (user !== null) {
-            if (!user.permissions.user || !user.permissions.user[feature]) {
+            try {
+                const permissionFilter = where().can(user).do(feature, 'user');
+
+                if (permissionFilter !== null) {
+                    statement.push(`(${permissionFilter.statement})`);
+                    Object.assign(replacement, permissionFilter.replacements);
+                }
+            } catch (error) {
+                // une erreur doit signifier que l'utilisateur n'a pas les permissions nécessaires, donc on retourne un tableau vide
                 return [];
             }
-
-            const featureLevel = user.permissions.user[feature].geographic_level;
-            const userLevel = user.organization.location.type;
-
-            if (featureLevel !== 'nation' && (featureLevel !== 'local' || userLevel !== 'nation')) {
-                if (user.organization.location.region === null) {
-                    return [];
-                }
-
-                where.push({
-                    location: {
-                        query: 'organizations.region_code',
-                        value: user.organization.location.region.code,
-                    },
-                });
-            }
         }
-
-        const whereClause = where.map((clauses, index) => {
-            const clauseGroup = Object.keys(clauses).map((column) => {
-                replacements[`${column}${index}`] = clauses[column].value || clauses[column];
-                return `${clauses[column].query || `users.${column}`} ${clauses[column].operator || 'IN'} (:${column}${index})`;
-            }).join(' OR ');
-
-            return `(${clauseGroup})`;
-        }).join(' AND ');
 
         const charte = await charteEngagementModel.getLatest();
         let latestCharte = null;
@@ -240,6 +226,7 @@ module.exports = (database) => {
                 organizations.epci_name,
                 organizations.city_code,
                 organizations.city_name,
+                cities.fk_main AS city_main,
                 organizations.latitude,
                 organizations.longitude,
                 organization_types.organization_type_id,
@@ -271,6 +258,14 @@ module.exports = (database) => {
             LEFT JOIN
                 localized_organizations AS organizations ON users.fk_organization = organizations.organization_id
             LEFT JOIN
+                cities ON organizations.city_code = cities.code
+            LEFT JOIN
+                epci ON organizations.epci_code = epci.code
+            LEFT JOIN
+                departements ON organizations.departement_code = departements.code
+            LEFT JOIN
+                regions ON organizations.region_code = regions.code
+            LEFT JOIN
                 organization_types ON organizations.fk_type = organization_types.organization_type_id
             LEFT JOIN
                 organization_categories ON organization_types.fk_category = organization_categories.uid
@@ -280,7 +275,7 @@ module.exports = (database) => {
                 organizations AS activator_organization ON activator.fk_organization = activator_organization.organization_id
             LEFT JOIN
                 roles_regular ON organization_types.fk_role = roles_regular.role_id
-            ${where.length > 0 ? `WHERE ${whereClause}` : ''}
+            ${statement.length > 0 ? `WHERE ${statement.join(' AND ')}` : ''}
             ORDER BY
                 CASE
                     WHEN
@@ -298,7 +293,7 @@ module.exports = (database) => {
                 upper(users.first_name) ASC`,
             {
                 type: database.QueryTypes.SELECT,
-                replacements,
+                replacements: replacement,
             },
         );
 
@@ -511,7 +506,7 @@ module.exports = (database) => {
         ),
 
         findByOrganizationCategory: (organizationCategoryId, geographicFilter = undefined, filters = {}) => {
-            const where = [
+            const whereArr = [
                 {
                     organizationCategory: {
                         query: 'organization_categories.uid',
@@ -522,14 +517,14 @@ module.exports = (database) => {
 
             if (geographicFilter !== undefined) {
                 if (geographicFilter.type === 'departement') {
-                    where.push({
+                    whereArr.push({
                         departement: {
                             query: 'organizations.departement_code',
                             value: [geographicFilter.value],
                         },
                     });
                 } else if (geographicFilter.type === 'region') {
-                    where.push({
+                    whereArr.push({
                         departement: {
                             query: 'organizations.region_code',
                             value: [geographicFilter.value],
@@ -538,7 +533,7 @@ module.exports = (database) => {
                 }
             }
 
-            return query(where, filters);
+            return query(whereArr, filters);
         },
 
         update: async (userId, values, transaction = undefined) => {
@@ -780,7 +775,7 @@ module.exports = (database) => {
     };
 
     model.findForRegion = async (regionCode, name = undefined) => {
-        const where = [
+        const whereArr = [
             {
                 nationalUser: {
                     query: 'organizations.location_type',
@@ -797,7 +792,7 @@ module.exports = (database) => {
             },
         ];
         if (name !== undefined) {
-            where.push({
+            whereArr.push({
                 firstName: {
                     query: 'users.first_name',
                     operator: 'ILIKE',
@@ -812,7 +807,7 @@ module.exports = (database) => {
             });
         }
 
-        return query(where, {});
+        return query(whereArr, {});
     };
 
     return model;

--- a/server/services/permissionService.js
+++ b/server/services/permissionService.js
@@ -1,0 +1,182 @@
+module.exports = {
+
+    can: user => ({
+        do: (feature, entity) => ({
+            on(location, plan = null) {
+                // on vérifie que l'utilisateur dispose de la permission demandée
+                if (!user || !user.permissions || !user.permissions[entity]) {
+                    return false;
+                }
+
+                const permission = user.permissions[entity][feature];
+                if (!permission || permission.allowed !== true) {
+                    return false;
+                }
+
+                if (permission.geographic_level === 'nation') {
+                    return true;
+                }
+
+                // on interprète la valeur spéciale "own", dédiée exclusivement aux permissions plan.update et plan.updateMarks
+                if (permission.geographic_level === 'own') {
+                    if (!plan) {
+                        throw new Error('Le dispositif est obligatoire pour une permission de type `own`');
+                    }
+
+                    if (feature === 'update') {
+                        if (!plan.government_contacts) {
+                            return false;
+                        }
+
+                        return plan.government_contacts.some(({ id }) => id === user.id);
+                    }
+
+                    if (feature === 'updateMarks') {
+                        if (!plan.operator_contacts) {
+                            return false;
+                        }
+
+                        return plan.operator_contacts.some(contact => contact.organization.id === user.organization.id);
+                    }
+
+                    throw new Error('La permission de type `own` ne peut pas être résolue pour une autre feature que `update` et `updateMarks`');
+                }
+
+                // on détermine le niveau géographique de la permission
+                // (notamment, on traduit la valeur spéciale "local" en un niveau géographique spécifique)
+                let permissionLevel;
+                if (permission.geographic_level === 'local') {
+                    switch (user.organization.location.type) {
+                        case 'nation':
+                            return true;
+
+                        case 'region':
+                            permissionLevel = 'region';
+                            break;
+
+                        // pour tout utilisateur en-dessous du niveau régional, une permission "local" se traduit en permission "départementale"
+                        default:
+                            permissionLevel = 'departement';
+                    }
+                } else {
+                    permissionLevel = user.permissions.shantytown.export.geographic_level;
+                }
+
+                // on vérifie que l'utilisateur a bien le bon niveau géographique pour avoir la permission
+                if (!location[permissionLevel] || !user.organization.location[permissionLevel]) {
+                    return false;
+                }
+
+                return location[permissionLevel].code === user.organization.location[permissionLevel].code;
+            },
+        }),
+    }),
+
+    where: () => ({
+        can: user => ({
+            do(feature, entity) {
+                // on vérifie que l'utilisateur dispose de la permission demandée
+                if (!user || !user.permissions || !user.permissions[entity]) {
+                    throw new Error(`L'utilisateur ne dispose pas de la permission ${entity}.${feature}`);
+                }
+
+                const permission = user.permissions[entity][feature];
+                if (!permission || permission.allowed !== true) {
+                    throw new Error(`L'utilisateur ne dispose pas de la permission ${entity}.${feature}`);
+                }
+
+                // on détermine quel est le niveau géographique de la permission (on traduit notamment "local" en un niveau géographique concret)
+                let permissionLevel = permission.geographic_level;
+                if (permissionLevel === 'local') {
+                    switch (user.organization.location.type) {
+                        case 'nation':
+                        case 'region':
+                            permissionLevel = user.organization.location.type;
+                            break;
+
+                        // pour tout utilisateur en-dessous du niveau régional, une permission "local" se traduit en permission "départementale"
+                        default:
+                            permissionLevel = 'departement';
+                    }
+                }
+
+                switch (permissionLevel) {
+                    case 'nation':
+                        return null;
+
+                    case 'region':
+                        if (!user.organization.location.region) {
+                            throw new Error('Impossible d\'accorder une permission régionale à un utilisateur national');
+                        }
+
+                        return {
+                            statement: 'regions.code IN (:where_region)',
+                            replacements: {
+                                where_region: [user.organization.location.region.code],
+                            },
+                        };
+
+                    case 'departement':
+                        if (!user.organization.location.departement) {
+                            throw new Error('Impossible d\'accorder une permission départementale à un utilisateur non rattaché à un département');
+                        }
+
+                        return {
+                            statement: 'departements.code IN (:where_departement)',
+                            replacements: {
+                                where_departement: [user.organization.location.departement.code],
+                            },
+                        };
+
+                    case 'epci':
+                        if (!user.organization.location.epci) {
+                            throw new Error('Impossible d\'accorder une permission intercommunale à un utilisateur non rattaché à une epci');
+                        }
+
+                        if (entity === 'plan') {
+                            throw new Error('Impossible d\'accorder une permission de niveau `epci` à l\'entité `plan`');
+                        }
+
+                        return {
+                            statement: 'epci.code IN (:where_epci)',
+                            replacements: {
+                                where_epci: [user.organization.location.epci.code],
+                            },
+                        };
+
+                    case 'city':
+                        if (!user.organization.location.city) {
+                            throw new Error('Impossible d\'accorder une permission communale à un utilisateur non rattaché à une commune');
+                        }
+
+                        if (entity === 'plan') {
+                            throw new Error('Impossible d\'accorder une permission de niveau `city` à l\'entité `plan`');
+                        }
+
+                        return {
+                            statement: 'cities.code IN (:where_city) OR cities.fk_main IN (:where_city)',
+                            replacements: {
+                                where_city: [user.organization.location.city.code],
+                            },
+                        };
+
+                    case 'own':
+                        if (entity !== 'plan') {
+                            throw new Error(`Impossible d'accorder une permission de niveau \`own\` à l'entité \`${entity}\``);
+                        }
+
+                        return {
+                            statement: '(plan_managers && ARRAY[:where_managers]) OR (plan_operators && ARRAY[:where_managers])',
+                            replacements: {
+                                where_managers: [user.id],
+                            },
+                        };
+
+                    default:
+                        throw new Error('Niveau de permission inconnu');
+                }
+            },
+        }),
+    }),
+
+};

--- a/server/services/permissionService.js
+++ b/server/services/permissionService.js
@@ -39,7 +39,17 @@ module.exports = {
                         return plan.operator_contacts.some(contact => contact.organization.id === user.organization.id);
                     }
 
-                    throw new Error('La permission de type `own` ne peut pas être résolue pour une autre feature que `update` et `updateMarks`');
+                    // pour toute autre feature que "update" et "updateMarks", il suffit que
+                    // l'utilisateur soit soit pilote, soit opérateur
+                    if (plan.government_contacts && plan.government_contacts.some(({ id }) => id === user.id)) {
+                        return true;
+                    }
+
+                    if (plan.operator_contacts && plan.operator_contacts.some(contact => contact.organization.id === user.organization.id)) {
+                        return true;
+                    }
+
+                    return false;
                 }
 
                 // on détermine le niveau géographique de la permission

--- a/server/utils/sql.js
+++ b/server/utils/sql.js
@@ -1,0 +1,84 @@
+
+function buildClause(defaultTable, index, key, definition) {
+    // parse
+    const column = (definition && definition.query) || `${defaultTable}.${key}`;
+    const not = (definition && definition.not) === true;
+    const replacementKey = `${key}${index}`;
+    const operator = (definition && definition.operator) || 'IN';
+
+    let replacementValue = definition;
+    if (definition && Object.prototype.hasOwnProperty.call(definition, 'value')) {
+        replacementValue = definition.value;
+    }
+
+    // build
+    return {
+        statement: `(${column} ${not ? 'NOT' : ''} ${operator} (:${replacementKey}))`,
+        replacement: {
+            [replacementKey]: replacementValue,
+        },
+    };
+}
+
+
+function buildClauseGroup(defaultTable, index, group) {
+    const statement = [];
+    const replacement = {};
+
+    Object.keys(group).forEach((key) => {
+        const {
+            statement: subStatement,
+            replacement: subReplacement,
+        } = buildClause(defaultTable, index, key, group[key]);
+
+        statement.push(subStatement);
+        Object.assign(replacement, subReplacement);
+    });
+
+    return {
+        statement: `(${statement.join(' OR ')})`,
+        replacement,
+    };
+}
+
+/**
+ * Example of valid input:
+ * [
+ *      {
+ *          population_total: 10,
+ *          trash_evacuation: { value: false },
+ *      },
+ *      {
+ *          departement: { value: '78', query: 'departements.code' },
+ *          status: { not: true, value: ['open', 'unknown'] },
+ *      },
+ *      {
+ *          name: { operator: 'ILIKE', value: '%a%' }
+ *      }
+ *  ]
+ *
+ *  Which should translate into:
+ *  (population_total IN (10) OR trash_evacuation IN (false))
+ *  AND
+ *  (departements.code IN ('78') OR status NOT IN ('open', 'unknown'))
+ *  AND
+ *  (name ILIKE ('%a%'))
+ */
+module.exports = {
+    buildWhere(defaultTable, clauseGroups) {
+        return clauseGroups.reduce((acc, group, index) => {
+            const {
+                statement: subStatement,
+                replacement: subReplacement,
+            } = buildClauseGroup(defaultTable, index, group);
+
+            return {
+                statement: [...acc.statement, subStatement],
+                replacement: { ...acc.replacement, ...subReplacement },
+            };
+        }, {
+            statement: [],
+            replacement: {},
+        });
+    },
+};

--- a/test/suites/server/services/permissionService/can.spec.js
+++ b/test/suites/server/services/permissionService/can.spec.js
@@ -241,12 +241,50 @@ describe.only('PermissionService', () => {
             ).to.be.false;
         });
 
-        it('Si la permission est de niveau `own` mais que la feature demandée n\'est ni `update` ni `updateMarks`, lance une exception', () => {
+        it('Si la permission est de niveau `own`, que la feature demandée n\'est ni `update` ni `updateMarks`, et que l\'utilisateur est pilote du dispositif, retourne true', () => {
+            const user = createUser({
+                id: 666,
+                organization: {
+                    id: 666,
+                },
+                permissions: { plan: { list: { geographic_level: 'own' } } },
+            });
+
             expect(
-                () => can(createUser({
-                    permissions: { plan: { list: { geographic_level: 'own' } } },
-                })).do('list', 'plan').on(location.nation(), createPlan()),
-            ).to.throw('La permission de type `own` ne peut pas être résolue pour une autre feature que `update` et `updateMarks`');
+                can(user).do('list', 'plan').on(location.nation(), createPlan({
+                    government_contacts: [user],
+                })),
+            ).to.be.true;
+        });
+
+        it('Si la permission est de niveau `own`, que la feature demandée n\'est ni `update` ni `updateMarks`, et que l\'utilisateur est opérateur du dispositif, retourne true', () => {
+            const user = createUser({
+                id: 666,
+                organization: {
+                    id: 666,
+                },
+                permissions: { plan: { list: { geographic_level: 'own' } } },
+            });
+
+            expect(
+                can(user).do('list', 'plan').on(location.nation(), createPlan({
+                    operator_contacts: [user],
+                })),
+            ).to.be.true;
+        });
+
+        it('Si la permission est de niveau `own`, que la feature demandée n\'est ni `update` ni `updateMarks`, et que le dispositif n\'a ni pilote ni dispositif, retourne false', () => {
+            const user = createUser({
+                id: 666,
+                organization: {
+                    id: 666,
+                },
+                permissions: { plan: { list: { geographic_level: 'own' } } },
+            });
+
+            expect(
+                can(user).do('list', 'plan').on(location.nation(), {}),
+            ).to.be.false;
         });
     });
 });

--- a/test/suites/server/services/permissionService/can.spec.js
+++ b/test/suites/server/services/permissionService/can.spec.js
@@ -1,0 +1,252 @@
+const { expect } = require('chai');
+const { can } = require('#server/services/permissionService');
+const location = require('#test/utils/location');
+const { serialized: createUser } = require('#test/utils/user');
+const { serialized: createPlan } = require('#test/utils/plan');
+
+describe.only('PermissionService', () => {
+    describe('.can(user).do(feature, entity).on(location)', () => {
+        it('Si l\'utilisateur n\'est pas défini, retourne false', () => {
+            expect(
+                can(undefined).do('list', 'shantytown').on(location.city()),
+            ).to.be.false;
+        });
+
+        it('Si l\'utilisateur n\'a pas de permissions définies, retourne false', () => {
+            expect(
+                can(createUser({ permissions: undefined })).do('list', 'shantytown').on(location.city()),
+            ).to.be.false;
+        });
+
+        it('Si l\'utilisateur n\'a pas de permissions pour l\'entité demandée, retourne false', () => {
+            expect(
+                can(createUser()).do('list', 'whatever').on(location.city()),
+            ).to.be.false;
+        });
+
+        it('Si l\'utilisateur n\'a pas de permissions pour la feature demandée, retourne false', () => {
+            expect(
+                can(createUser()).do('whatever', 'shantytown').on(location.city()),
+            ).to.be.false;
+        });
+
+        it('Si la permission est allowed=false pour l\'utilisateur, retourne false', () => {
+            expect(
+                can(createUser({
+                    permissions: { shantytown: { list: { allowed: false } } },
+                })).do('list', 'shantytown').on(location.city()),
+            ).to.be.false;
+        });
+
+        it('Si la permission est autorisée au niveau national, retourne true', () => {
+            expect(
+                can(createUser()).do('list', 'shantytown').on(location.nation()),
+            ).to.be.true;
+        });
+
+        const dataset = [
+            // nation
+            {
+                test: 'l\'utilisateur est de niveau national, retourne true',
+                user: location.nation(),
+                requested: location.nation(),
+                expected: true,
+            },
+            // region
+            {
+                test: 'l\'utilisateur est de niveau régional et demande une permission sur une ville de la région, retourne true',
+                user: location.region(),
+                requested: location.city(),
+                expected: true,
+            },
+            {
+                test: 'l\'utilisateur est de niveau régional et demande une permission sur une ville d\'une autre région, retourne false',
+                user: location.region(),
+                requested: location.city({ region: { code: '99' } }),
+                expected: false,
+            },
+            {
+                test: 'l\'utilisateur est de niveau régional et demande une permission au niveau national, retourne false',
+                user: location.region(),
+                requested: location.nation(),
+                expected: false,
+            },
+            // departement
+            {
+                test: 'l\'utilisateur est de niveau départemental et demande une permission sur une ville du département, retourne true',
+                user: location.departement(),
+                requested: location.city(),
+                expected: true,
+            },
+            {
+                test: 'l\'utilisateur est de niveau départemental et demande une permission sur une ville d\'un autre département, retourne false',
+                user: location.departement(),
+                requested: location.city({ departement: { code: '99' } }),
+                expected: false,
+            },
+            {
+                test: 'l\'utilisateur est de niveau départemental et demande une permission au niveau régional, retourne false',
+                user: location.departement(),
+                requested: location.region(),
+                expected: false,
+            },
+            {
+                test: 'l\'utilisateur est de niveau départemental et demande une permission au niveau national, retourne false',
+                user: location.departement(),
+                requested: location.nation(),
+                expected: false,
+            },
+            // epci
+            {
+                test: 'l\'utilisateur est de niveau epci et demande une permission sur une ville du département associé, retourne true',
+                user: location.epci(),
+                requested: location.city(),
+                expected: true,
+            },
+            {
+                test: 'l\'utilisateur est de niveau epci et demande une permission au niveau départemental, retourne true',
+                user: location.epci(),
+                requested: location.departement(),
+                expected: true,
+            },
+            {
+                test: 'l\'utilisateur est de niveau epci et demande une permission sur une ville d\'un autre département, retourne false',
+                user: location.epci(),
+                requested: location.city({ departement: { code: '99' } }),
+                expected: false,
+            },
+            {
+                test: 'l\'utilisateur est de niveau epci et demande une permission au niveau régional, retourne false',
+                user: location.epci(),
+                requested: location.region(),
+                expected: false,
+            },
+            {
+                test: 'l\'utilisateur est de niveau epci et demande une permission au niveau national, retourne false',
+                user: location.epci(),
+                requested: location.nation(),
+                expected: false,
+            },
+            // city
+            {
+                test: 'l\'utilisateur est de niveau communal et demande une permission sur un arrondissement de sa ville, retourne true',
+                user: location.city(),
+                requested: location.district(),
+                expected: true,
+            },
+            {
+                test: 'l\'utilisateur est de niveau communal et demande une permission sur sa ville, retourne true',
+                user: location.city(),
+                requested: location.city(),
+                expected: true,
+            },
+            {
+                test: 'l\'utilisateur est de niveau communal et demande une permission au niveau départemental, retourne true',
+                user: location.city(),
+                requested: location.departement(),
+                expected: true,
+            },
+            {
+                test: 'l\'utilisateur est de niveau communal et demande une permission sur une ville d\'un autre département, retourne false',
+                user: location.city(),
+                requested: location.city({ departement: { code: '99' } }),
+                expected: false,
+            },
+            {
+                test: 'l\'utilisateur est de niveau communal et demande une permission au niveau régional, retourne false',
+                user: location.city(),
+                requested: location.region(),
+                expected: false,
+            },
+            {
+                test: 'l\'utilisateur est de niveau v et demande une permission au niveau national, retourne false',
+                user: location.city(),
+                requested: location.nation(),
+                expected: false,
+            },
+        ];
+
+        dataset.forEach(({
+            test, user: userLocation, requested: requestedLocation, expected,
+        }) => {
+            it(`Si la permission est autorisée au niveau local et que ${test}`, () => {
+                expect(
+                    can(createUser({
+                        permissions: { shantytown: { list: { geographic_level: 'local' } } },
+                        organization: {
+                            location: userLocation,
+                        },
+                    })).do('list', 'shantytown').on(requestedLocation),
+                ).to.be.eql(expected);
+            });
+        });
+
+        it('Si la permission est de niveau `own` mais que le dispositif est null, lance une exception', () => {
+            expect(
+                () => can(createUser({
+                    permissions: { plan: { list: { geographic_level: 'own' } } },
+                })).do('list', 'plan').on(location.nation(), null),
+            ).to.throw('Le dispositif est obligatoire pour une permission de type `own`');
+        });
+
+        it('Si la permission est de niveau `own` pour la feature `update` et que le dispositif n\'a pas de pilote, retourne false', () => {
+            expect(
+                can(createUser({
+                    permissions: { plan: { update: { geographic_level: 'own' } } },
+                })).do('update', 'plan').on(location.nation(), {}),
+            ).to.be.false;
+        });
+
+        it('Si la permission est de niveau `own` pour la feature `update` et que l\'utilisateur est le pilote du dispositif, retourne true', () => {
+            expect(
+                can(createUser({
+                    permissions: { plan: { update: { geographic_level: 'own' } } },
+                })).do('update', 'plan').on(location.nation(), createPlan()),
+            ).to.be.true;
+        });
+
+        it('Si la permission est de niveau `own` pour la feature `update` et que l\'utilisateur n\'est pas le pilote du dispositif, retourne false', () => {
+            expect(
+                can(createUser({
+                    id: 3,
+                    permissions: { plan: { update: { geographic_level: 'own' } } },
+                })).do('update', 'plan').on(location.nation(), createPlan()),
+            ).to.be.false;
+        });
+
+        it('Si la permission est de niveau `own` pour la feature `updateMarks` et que le dispositif n\'a pas d\'opérateur, retourne false', () => {
+            expect(
+                can(createUser({
+                    permissions: { plan: { updateMarks: { geographic_level: 'own' } } },
+                })).do('updateMarks', 'plan').on(location.nation(), {}),
+            ).to.be.false;
+        });
+
+        it('Si la permission est de niveau `own` pour la feature `updateMarks` et que l\'utilisateur est un opérateur du dispositif, retourne true', () => {
+            expect(
+                can(createUser({
+                    permissions: { plan: { updateMarks: { geographic_level: 'own' } } },
+                })).do('updateMarks', 'plan').on(location.nation(), createPlan()),
+            ).to.be.true;
+        });
+
+        it('Si la permission est de niveau `own` pour la feature `updateMarks` et que l\'utilisateur n\'est pas un opérateur du dispositif, retourne false', () => {
+            expect(
+                can(createUser({
+                    organization: {
+                        id: 3,
+                    },
+                    permissions: { plan: { updateMarks: { geographic_level: 'own' } } },
+                })).do('updateMarks', 'plan').on(location.nation(), createPlan()),
+            ).to.be.false;
+        });
+
+        it('Si la permission est de niveau `own` mais que la feature demandée n\'est ni `update` ni `updateMarks`, lance une exception', () => {
+            expect(
+                () => can(createUser({
+                    permissions: { plan: { list: { geographic_level: 'own' } } },
+                })).do('list', 'plan').on(location.nation(), createPlan()),
+            ).to.throw('La permission de type `own` ne peut pas être résolue pour une autre feature que `update` et `updateMarks`');
+        });
+    });
+});

--- a/test/suites/server/services/permissionService/where.spec.js
+++ b/test/suites/server/services/permissionService/where.spec.js
@@ -1,0 +1,185 @@
+const { expect } = require('chai');
+const { where } = require('#server/services/permissionService');
+const { serialized: createUser } = require('#test/utils/user');
+const location = require('#test/utils/location');
+
+describe.only('PermissionService', () => {
+    describe('.where().can(user).do(feature, entity)', () => {
+        it('Si l\'utilisateur n\'est pas défini, lance une exception', () => {
+            expect(
+                () => where().can(undefined).do('list', 'shantytown'),
+            ).to.throw('L\'utilisateur ne dispose pas de la permission shantytown.list');
+        });
+
+        it('Si l\'utilisateur est défini mais ne dispose pas de permissions, lance une exception', () => {
+            expect(
+                () => where().can(createUser({ permissions: undefined })).do('list', 'shantytown'),
+            ).to.throw('L\'utilisateur ne dispose pas de la permission shantytown.list');
+        });
+
+        it('Si l\'utilisateur est défini mais ne dispose pas de permissions pour l\'entitée demandée, lance une exception', () => {
+            expect(
+                () => where().can(createUser()).do('list', 'whatever'),
+            ).to.throw('L\'utilisateur ne dispose pas de la permission whatever.list');
+        });
+
+        it('Si l\'utilisateur est défini mais ne dispose pas de la permission demandée, lance une exception', () => {
+            expect(
+                () => where().can(createUser()).do('whatever', 'shantytown'),
+            ).to.throw('L\'utilisateur ne dispose pas de la permission shantytown.whatever');
+        });
+
+        it('Si l\'utilisateur est défini mais la permission demandée est set à allowed=false, lance une exception', () => {
+            expect(
+                () => where().can(createUser({
+                    permissions: { shantytown: { list: { allowed: false } } },
+                })).do('list', 'shantytown'),
+            ).to.throw('L\'utilisateur ne dispose pas de la permission shantytown.list');
+        });
+
+        it('Si l\'utilisateur dispose de la permission demandée au niveau national, retourne null', () => {
+            expect(
+                where().can(createUser()).do('list', 'shantytown'),
+            ).to.be.eql(null);
+        });
+
+        it('Si l\'utilisateur dispose de la permission demandée au niveau régional et qu\'il est de niveau communal, retourne sa région', () => {
+            expect(
+                where().can(createUser({
+                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'region' } } },
+                    organization: { location: location.city() },
+                })).do('list', 'shantytown'),
+            ).to.be.eql({ statement: 'regions.code IN (:where_region)', replacements: { where_region: ['11'] } });
+        });
+
+        it('Si l\'utilisateur dispose de la permission demandée au niveau régional et qu\'il est de niveau national, lance une exception', () => {
+            expect(
+                () => where().can(createUser({
+                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'region' } } },
+                })).do('list', 'shantytown'),
+            ).to.throw('Impossible d\'accorder une permission régionale à un utilisateur national');
+        });
+
+        it('Si l\'utilisateur dispose de la permission demandée au niveau départemental et qu\'il est de niveau communal, retourne son département', () => {
+            expect(
+                where().can(createUser({
+                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'departement' } } },
+                    organization: { location: location.city() },
+                })).do('list', 'shantytown'),
+            ).to.be.eql({ statement: 'departements.code IN (:where_departement)', replacements: { where_departement: ['92'] } });
+        });
+
+        it('Si l\'utilisateur dispose de la permission demandée au niveau départemental et qu\'il est de niveau régional, lance une exception', () => {
+            expect(
+                () => where().can(createUser({
+                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'departement' } } },
+                    organization: { location: location.region() },
+                })).do('list', 'shantytown'),
+            ).to.throw('Impossible d\'accorder une permission départementale à un utilisateur non rattaché à un département');
+        });
+
+        it('Si l\'utilisateur dispose de la permission demandée au niveau intercommunal et qu\'il est de niveau intercommunal, retourne son epci', () => {
+            expect(
+                where().can(createUser({
+                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'epci' } } },
+                    organization: { location: location.city() },
+                })).do('list', 'shantytown'),
+            ).to.be.eql({ statement: 'epci.code IN (:where_epci)', replacements: { where_epci: ['200054781'] } });
+        });
+
+        it('Si l\'utilisateur dispose de la permission demandée au niveau intercommunal et qu\'il est de niveau départemental, lance une exception', () => {
+            expect(
+                () => where().can(createUser({
+                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'epci' } } },
+                    organization: { location: location.departement() },
+                })).do('list', 'shantytown'),
+            ).to.throw('Impossible d\'accorder une permission intercommunale à un utilisateur non rattaché à une epci');
+        });
+
+        it('Si l\'utilisateur dispose de la permission demandée au niveau communal et qu\'il est de niveau communal, retourne sa commune', () => {
+            expect(
+                where().can(createUser({
+                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'city' } } },
+                    organization: { location: location.city() },
+                })).do('list', 'shantytown'),
+            ).to.be.eql({ statement: 'cities.code IN (:where_city) OR cities.fk_main IN (:where_city)', replacements: { where_city: ['75056'] } });
+        });
+
+        it('Si l\'utilisateur dispose de la permission demandée au niveau communal et qu\'il est de niveau intercommunal, lance une exception', () => {
+            expect(
+                () => where().can(createUser({
+                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'city' } } },
+                    organization: { location: location.epci() },
+                })).do('list', 'shantytown'),
+            ).to.throw('Impossible d\'accorder une permission communale à un utilisateur non rattaché à une commune');
+        });
+
+        it('Si l\'utilisateur dispose de la permission demandée au niveau local et qu\'il est de niveau national, retourne null', () => {
+            expect(
+                where().can(createUser({
+                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'local' } } },
+                })).do('list', 'shantytown'),
+            ).to.be.eql(null);
+        });
+
+        it('Si l\'utilisateur dispose de la permission demandée au niveau local et qu\'il est de niveau régional, retourne sa région', () => {
+            expect(
+                where().can(createUser({
+                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'local' } } },
+                    organization: { location: location.region() },
+                })).do('list', 'shantytown'),
+            ).to.be.eql({ statement: 'regions.code IN (:where_region)', replacements: { where_region: ['11'] } });
+        });
+
+        it('Si l\'utilisateur dispose de la permission demandée au niveau local et qu\'il est de niveau communal, retourne son département', () => {
+            expect(
+                where().can(createUser({
+                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'local' } } },
+                    organization: { location: location.city() },
+                })).do('list', 'shantytown'),
+            ).to.be.eql({ statement: 'departements.code IN (:where_departement)', replacements: { where_departement: ['92'] } });
+        });
+
+        it('Si l\'utilisateur dispose de la permission demandée au niveau own, et que l\'entité n\'est pas plan, lance une exception', () => {
+            expect(
+                () => where().can(createUser({
+                    permissions: { shantytown: { update: { allowed: true, geographic_level: 'own' } } },
+                })).do('update', 'shantytown'),
+            ).to.throw('Impossible d\'accorder une permission de niveau `own` à l\'entité `shantytown`');
+        });
+
+        it('Si l\'utilisateur dispose de la permission demandée au niveau own, retourne un filtre sur les managers et operators', () => {
+            expect(
+                where().can(createUser({
+                    permissions: { plan: { list: { allowed: true, geographic_level: 'own' } } },
+                })).do('list', 'plan'),
+            ).to.be.eql({ statement: '(plan_managers && ARRAY[:where_managers]) OR (plan_operators && ARRAY[:where_managers])', replacements: { where_managers: [2] } });
+        });
+
+        it('Si l\'utilisateur dispose de la permission demandée au niveau epci pour l\'entité plan, lance une exception', () => {
+            expect(
+                () => where().can(createUser({
+                    permissions: { plan: { list: { allowed: true, geographic_level: 'epci' } } },
+                    organization: { location: location.city() },
+                })).do('list', 'plan'),
+            ).to.throw('Impossible d\'accorder une permission de niveau `epci` à l\'entité `plan`');
+        });
+
+        it('Si l\'utilisateur dispose de la permission demandée au niveau city pour l\'entité plan, lance une exception', () => {
+            expect(
+                () => where().can(createUser({
+                    permissions: { plan: { list: { allowed: true, geographic_level: 'city' } } },
+                    organization: { location: location.city() },
+                })).do('list', 'plan'),
+            ).to.throw('Impossible d\'accorder une permission de niveau `city` à l\'entité `plan`');
+        });
+
+        it('Si l\'utilisateur dispose de la permission demandée à un niveau inconnu, lance une exception', () => {
+            expect(
+                () => where().can(createUser({
+                    permissions: { shantytown: { list: { allowed: true, geographic_level: 'whatever' } } },
+                })).do('list', 'shantytown'),
+            ).to.throw('Niveau de permission inconnu');
+        });
+    });
+});

--- a/test/utils/changelog.js
+++ b/test/utils/changelog.js
@@ -1,3 +1,5 @@
+const merge = require('deepmerge');
+
 module.exports = {
     raw(override = {}) {
         const defaultObj = {
@@ -8,6 +10,6 @@ module.exports = {
             image: 'https://api.resorption-bidonvilles.localhost/assets/changelog/0.0.0/item_1.jpg',
         };
 
-        return Object.assign(defaultObj, override);
+        return merge(defaultObj, override);
     },
 };

--- a/test/utils/location.js
+++ b/test/utils/location.js
@@ -1,0 +1,107 @@
+const merge = require('deepmerge');
+
+module.exports = {
+    district(override = {}) {
+        return merge({
+            type: 'city',
+            region: {
+                name: 'Île-de-France',
+                code: '11',
+            },
+            departement: {
+                name: 'Hauts-de-Seine',
+                code: '92',
+            },
+            epci: {
+                name: 'Métropole du Grand Paris',
+                code: '200054781',
+            },
+            city: {
+                name: 'Paris 1er Arrondissement',
+                code: '75101',
+                main: '75056',
+            },
+        }, override);
+    },
+
+    city(override = {}) {
+        return merge({
+            type: 'city',
+            region: {
+                name: 'Île-de-France',
+                code: '11',
+            },
+            departement: {
+                name: 'Hauts-de-Seine',
+                code: '92',
+            },
+            epci: {
+                name: 'Métropole du Grand Paris',
+                code: '200054781',
+            },
+            city: {
+                name: 'Paris',
+                code: '75056',
+                main: null,
+            },
+        }, override);
+    },
+
+    epci(override = {}) {
+        return merge({
+            type: 'epci',
+            region: {
+                name: 'Île-de-France',
+                code: '11',
+            },
+            departement: {
+                name: 'Hauts-de-Seine',
+                code: '92',
+            },
+            epci: {
+                name: 'Métropole du Grand Paris',
+                code: '200054781',
+            },
+            city: null,
+        }, override);
+    },
+
+    departement(override = {}) {
+        return merge({
+            type: 'departement',
+            region: {
+                name: 'Île-de-France',
+                code: '11',
+            },
+            departement: {
+                name: 'Hauts-de-Seine',
+                code: '92',
+            },
+            epci: null,
+            city: null,
+        }, override);
+    },
+
+    region(override = {}) {
+        return merge({
+            type: 'region',
+            region: {
+                name: 'Île-de-France',
+                code: '11',
+            },
+            departement: null,
+            epci: null,
+            city: null,
+        }, override);
+    },
+
+    nation() {
+        return {
+            type: 'nation',
+            region: null,
+            departement: null,
+            epci: null,
+            city: null,
+        };
+    },
+};

--- a/test/utils/plan.js
+++ b/test/utils/plan.js
@@ -1,0 +1,46 @@
+const merge = require('deepmerge');
+const { serialized: createUser } = require('#test/utils/user');
+
+module.exports = {
+    serialized(override = {}) {
+        const defaultPlan = {
+            id: 2,
+            name: 'Dispositif',
+            started_at: (new Date(2020, 0, 1, 0, 0, 0)).getTime(),
+            expected_to_end_at: (new Date(2022, 0, 1, 0, 0, 0)).getTime(),
+            closed_at: null,
+            updated_at: null,
+            in_and_out: true,
+            goals: 'Objectif de dispositif',
+            location_type: {
+                id: 'housing',
+                label: 'sur terrain d\'insertion',
+            },
+            location_details: null,
+            final_comment: null,
+            government_contacts: [
+                createUser(),
+            ],
+            departement: {
+                code: '78',
+                name: 'Yvelines',
+            },
+            region: {
+                code: '11',
+                name: 'Île-de-France',
+            },
+            operator_contacts: [
+                createUser(),
+            ],
+            states: [],
+            topics: [{
+                uid: 'health',
+                name: 'Santé',
+            }],
+            createdBy: 2,
+            updatedBy: null,
+        };
+
+        return merge(defaultPlan, override);
+    },
+};

--- a/test/utils/user.js
+++ b/test/utils/user.js
@@ -1,3 +1,5 @@
+const merge = require('deepmerge');
+
 module.exports = {
     serialized(override = {}) {
         const defaultUser = {
@@ -96,6 +98,6 @@ module.exports = {
             last_changelog: '0.0.0',
         };
 
-        return Object.assign(defaultUser, override);
+        return merge(defaultUser, override);
     },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1444,6 +1444,11 @@ deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
+deepmerge@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
+  integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
+
 define-properties@^1.1.2, define-properties@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"


### PR DESCRIPTION
- création d'un permissionService qui expose deux fonctions can() et where() qui respectivement indique si un utilisateur a le droit de faire une action sur une entité donnée, et génère les conditions à injecter dans une requête SQL pour effectuer une action de lecture. Ce service prend en compte le périmètre géographique.
- écriture de tests unitaires sur le permissionService
- création d'utilitaires pour les tests unitaires qui génèrent des données de test
- màj des sources (notamment validators et modèles) pour utiliser le permissionService (là où c'était faisable sans trop de complexité)