### PR TITLE
#patch (906) Ajout d'une notification mail à chaque commentaire

### DIFF
--- a/db/migrations/000109-01-create-view-user_permissions.js
+++ b/db/migrations/000109-01-create-view-user_permissions.js
@@ -1,0 +1,80 @@
+module.exports = {
+    up: queryInterface => queryInterface.sequelize.transaction(
+        transaction => queryInterface.dropTable('user_permissions', {
+            transaction,
+        })
+            .then(() => queryInterface.sequelize.query(
+                `CREATE VIEW user_permissions AS
+                (WITH summary AS
+                    (
+                    SELECT
+                        ROW_NUMBER() OVER(
+                            PARTITION BY t.user_id, t.fk_entity, t.fk_feature ORDER BY t.permission_priority ASC
+                        ) AS "rank",
+                        t.*
+                    FROM
+                        ((SELECT
+                            1 AS permission_priority,
+                            u.user_id,
+                            u.email,
+                            p.*
+                        FROM users u
+                        LEFT JOIN roles_admin ra ON u.fk_role = ra.role_id
+                        LEFT JOIN permissions p ON p.fk_role_admin = ra.role_id)
+                        UNION
+                        (SELECT
+                            2 AS permission_priority,
+                            u.user_id,
+                            u.email,
+                            p.*
+                        FROM users u
+                        LEFT JOIN permissions p ON p.fk_organization = u.fk_organization)
+                        UNION
+                        (SELECT
+                            3 AS permission_priority,
+                            u.user_id,
+                            u.email,
+                            p.*
+                        FROM users u
+                        LEFT JOIN organizations o ON u.fk_organization = o.organization_id
+                        LEFT JOIN organization_types ot ON o.fk_type = ot.organization_type_id
+                        LEFT JOIN permissions p ON p.fk_role_regular = ot.fk_role)) t
+                    )
+                    SELECT * FROM summary WHERE "rank" = 1 AND summary.permission_id IS NOT NULL)`,
+                {
+                    transaction,
+                },
+            )),
+    ),
+    down: (queryInterface, Sequelize) => queryInterface.sequelize.transaction(
+        transaction => queryInterface.sequelize.query(
+            'DROP VIEW user_permissions',
+            {
+                transaction,
+            },
+        ).then(() => queryInterface.createTable(
+            'user_permissions',
+            {
+                fk_permission: {
+                    type: Sequelize.INTEGER,
+                    primaryKey: true,
+                    allowNull: false,
+                },
+                created_at: {
+                    type: Sequelize.DATE,
+                    allowNull: false,
+                    defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+                },
+                updated_at: {
+                    type: Sequelize.DATE,
+                    allowNull: true,
+                    defaultValue: null,
+                    onUpdate: Sequelize.literal('CURRENT_TIMESTAMP'),
+                },
+            },
+            {
+                transaction,
+            },
+        )),
+    ),
+};

--- a/db/migrations/000109-02-create-view-shantytown_watchers.js
+++ b/db/migrations/000109-02-create-view-shantytown_watchers.js
@@ -1,0 +1,61 @@
+module.exports = {
+    up: queryInterface => queryInterface.sequelize.query(
+        `CREATE VIEW shantytown_watchers AS
+        (
+            (
+            SELECT
+                s.shantytown_id AS fk_shantytown,
+                u.user_id AS fk_user
+            FROM shantytowns s
+            LEFT JOIN cities c ON s.fk_city = c.code
+            LEFT JOIN departements d ON c.fk_departement = d.code
+            LEFT JOIN localized_organizations lo ON lo.region_code = d.fk_region
+            LEFT JOIN users u ON u.fk_organization = lo.organization_id
+            WHERE
+                lo.active = true
+                AND
+                u.fk_status = 'active'
+                AND
+                lo.location_type = 'region'
+                AND
+                u.fk_role = 'local_admin'
+            )
+    
+            UNION
+    
+            (
+            SELECT
+                s.shantytown_id AS fk_shantytown,
+                u.user_id AS fk_user
+            FROM shantytowns s
+            LEFT JOIN cities c ON s.fk_city = c.code
+            LEFT JOIN localized_organizations lo ON lo.departement_code = c.fk_departement
+            LEFT JOIN users u ON u.fk_organization = lo.organization_id
+            WHERE
+                lo.active = true
+                AND
+                u.fk_status = 'active'
+                AND
+                u.fk_role = 'local_admin'
+            )
+    
+            UNION
+    
+            (
+            SELECT
+                sa.fk_shantytown,
+                u.user_id AS fk_user
+            FROM shantytown_actors sa
+            LEFT JOIN users u ON sa.fk_user = u.user_id
+            LEFT JOIN organizations o ON u.fk_organization = o.organization_id
+            WHERE
+                u.fk_status = 'active'
+                AND
+                o.active = TRUE
+            )
+        )`,
+    ),
+    down: queryInterface => queryInterface.sequelize.query(
+        'DROP VIEW shantytown_watchers',
+    ),
+};

--- a/server/mails/new_comment.js
+++ b/server/mails/new_comment.js
@@ -1,0 +1,56 @@
+const { toString: dateToString } = require('#server/utils/date');
+const signature = require('./signature');
+const { frontUrl } = require('#server/config');
+
+
+module.exports = (shantytown, comment) => ({
+    Subject: `[ resorption-bidonvilles ] - Nouveau message site "${shantytown.usename}"`,
+
+    TextPart: `Bonjour,
+    
+    Un nouveau message a été publié par ${comment.createdBy.firstName} ${comment.createdBy.lastName.toUpperCase()} (${comment.createdBy.organization}) le ${dateToString(new Date(comment.createdAt * 1000))} sur le site situé ${shantytown.addressSimple} (${shantytown.departement.name}).
+
+    "${comment.description}"
+
+    Accéder à la fiche du site : ${frontUrl}/site/${shantytown.id}
+    Contacter ${comment.createdBy.firstName} ${comment.createdBy.lastName.toUpperCase()} : ${frontUrl}/annuaire/${comment.createdBy.organizationId}
+
+    Cordialement,
+
+    ${signature.TextPart}`,
+
+    HTMLPart: `<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "">
+        <html>
+            <head>
+                <link href="https://fonts.googleapis.com/css?family=Open+Sans&display=swap" rel="stylesheet">
+            </head>
+
+            <body style="max-width: 600px; width: 600px;" bgcolor="#ffffff">
+                <div class="container" style="font-family: 'Open Sans'; width: 600px;">
+                    <table style="width: 600px; font-family: 'Open Sans'; color: #000000;" border="0" cellpadding="0" cellspacing="0" width="600">
+                        <tbody>
+                            <tr>
+                                <td bgcolor="#ffffff">
+                                    Bonjour,<br/>
+                                    <br/>
+                                    Un nouveau message a été publié par ${comment.createdBy.firstName} ${comment.createdBy.lastName.toUpperCase()} (${comment.createdBy.organization}) le ${dateToString(new Date(comment.createdAt * 1000))} sur le site situé ${shantytown.addressSimple} (${shantytown.departement.name}).<br/>
+                                    <br/>
+                                    "${comment.description}"<br/>
+                                    <br/>
+                                    <a href="${frontUrl}/site/${shantytown.id}">Accéder à la fiche du site</a><br/>
+                                    <br/>
+                                    <a href="${frontUrl}/annuaire/${comment.createdBy.organizationId}">Contacter ${comment.createdBy.firstName} ${comment.createdBy.lastName.toUpperCase()}</a><br/>
+                                    <br/>
+                                    Cordialement,
+                                </td>
+                            </tr>
+                            <tr>
+                                <td bgcolor="#ffffff"><br/><br/></td>
+                            </tr>
+                            ${signature.HTMLPart}
+                        </tbody>
+                    </table>
+                </div>
+            </body>
+        </html>`,
+});

--- a/server/models/shantytownComment/create.js
+++ b/server/models/shantytownComment/create.js
@@ -11,20 +11,25 @@ const { sequelize } = require('#db/models');
 /**
  * @param {Model_ShantytownComment_Data} data
  */
-module.exports = data => sequelize.query(
-    `INSERT INTO shantytown_comments(
-        description,
-        fk_shantytown,
-        created_by,
-        private
-    )
-    VALUES (
-        :description,
-        :fk_shantytown,
-        :created_by,
-        :private
-    )`,
-    {
-        replacements: data,
-    },
-);
+module.exports = async (data) => {
+    const [[{ shantytown_comment_id }]] = await sequelize.query(
+        `INSERT INTO shantytown_comments(
+            description,
+            fk_shantytown,
+            created_by,
+            private
+        )
+        VALUES (
+            :description,
+            :fk_shantytown,
+            :created_by,
+            :private
+        )
+        RETURNING shantytown_comment_id`,
+        {
+            replacements: data,
+        },
+    );
+
+    return shantytown_comment_id;
+};

--- a/server/models/shantytownComment/findOne.js
+++ b/server/models/shantytownComment/findOne.js
@@ -1,0 +1,43 @@
+const { sequelize } = require('#db/models');
+const { serializeComment } = require('#server/models/shantytownModel')(sequelize);
+
+/**
+ * @param {Number} id A shantytown_comment_id
+ */
+module.exports = async (id) => {
+    const rows = await sequelize.query(
+        `SELECT
+            sc.shantytown_comment_id AS "commentId",
+            sc.description AS "commentDescription",
+            sc.fk_shantytown AS "shantytownId",
+            sc.created_at AS "commentCreatedAt",
+            sc.created_by "commentCreatedBy",
+            sc.private AS "commentPrivate",
+            u.first_name AS "userFirstName",
+            u.last_name AS "userLastName",
+            u.position AS "userPosition",
+            o.abbreviation AS "organizationAbbreviation",
+            o.name AS "organizationName",
+            o.organization_id AS "organizationId"
+        FROM
+            shantytown_comments sc
+        LEFT JOIN
+            users u ON sc.created_by = u.user_id
+        LEFT JOIN
+            organizations o ON u.fk_organization = o.organization_id
+        WHERE
+            sc.shantytown_comment_id = :id`,
+        {
+            type: sequelize.QueryTypes.SELECT,
+            replacements: {
+                id,
+            },
+        },
+    );
+
+    if (rows.length !== 1) {
+        return null;
+    }
+
+    return serializeComment(rows[0]);
+};

--- a/server/models/shantytownComment/index.js
+++ b/server/models/shantytownComment/index.js
@@ -1,5 +1,7 @@
 const create = require('./create');
+const findOne = require('./findOne');
 
 module.exports = {
     create,
+    findOne,
 };

--- a/server/models/shantytownModel.js
+++ b/server/models/shantytownModel.js
@@ -276,7 +276,7 @@ function serializeComment(comment) {
             },
             shantytown: comment.shantytownId,
         },
-        comment.covidCommentDate !== null
+        comment.covidCommentDate
             ? {
                 covid: {
                     date: comment.covidCommentDate.getTime() / 1000,
@@ -865,6 +865,8 @@ module.exports = (database) => {
     }
 
     return {
+        serializeComment,
+
         findAll: (user, filters = [], feature = 'list', order = undefined) => query(filters, order, user, feature),
 
         findOne: async (user, shantytownId) => {

--- a/server/models/userModel.js
+++ b/server/models/userModel.js
@@ -815,5 +815,28 @@ module.exports = (database) => {
         return query(where, {});
     };
 
+    model.getShantytownWatchers = async (shantytownId, includePrivate) => database.query(
+        `
+            SELECT
+                u.email,
+                u.first_name,
+                u.last_name
+            FROM shantytown_watchers sw
+            LEFT JOIN users u ON sw.fk_user = u.user_id
+            LEFT JOIN user_permissions up ON sw.fk_user = up.user_id
+            WHERE
+                    sw.fk_shantytown = :shantytownId
+                AND up.fk_feature = 'listPrivate'
+                AND up.fk_entity = 'shantytown_comment'
+                ${includePrivate === true ? 'AND up.allowed = true' : ''}
+            `,
+        {
+            type: database.QueryTypes.SELECT,
+            replacements: {
+                shantytownId,
+            },
+        },
+    );
+
     return model;
 };

--- a/test/suites/server/services/shantytownComment/createComment.spec.js
+++ b/test/suites/server/services/shantytownComment/createComment.spec.js
@@ -10,24 +10,34 @@ const { sequelize } = require('#db/models');
 const shantytownCommentModel = require('#server/models/shantytownComment');
 const shantytownModel = require('#server/models/shantytownModel')(sequelize);
 const slackUtils = require('#server/utils/slack');
+const userModel = require('#server/models/userModel')(sequelize);
+const mailService = require('#server/services/mailService');
 const ServiceError = require('#server/errors/ServiceError');
 
 const createComment = proxyquire('#server/services/shantytownComment/createComment', {
     '#server/models/shantytownModel': () => shantytownModel,
+    '#server/models/userModel': () => userModel,
 });
 const { serialized: fakeUser } = require('#test/utils/user');
+const { serialized: fakeComment } = require('#test/utils/shantytownComment');
 
 
 describe.only('services/shantytownComment', () => {
     const dependencies = {
         createComment: undefined,
+        findOneComment: undefined,
         getComments: undefined,
         triggerNewComment: undefined,
+        getShantytownWatchers: undefined,
+        sendMail: undefined,
     };
     beforeEach(() => {
         dependencies.createComment = sinon.stub(shantytownCommentModel, 'create');
+        dependencies.findOneComment = sinon.stub(shantytownCommentModel, 'findOne');
         dependencies.getComments = sinon.stub(shantytownModel, 'getComments');
         dependencies.triggerNewComment = sinon.stub(slackUtils, 'triggerNewComment');
+        dependencies.getShantytownWatchers = sinon.stub(userModel, 'getShantytownWatchers');
+        dependencies.sendMail = sinon.stub(mailService, 'send');
     });
     afterEach(() => {
         Object.values(dependencies).forEach(stub => stub && stub.restore());
@@ -48,8 +58,14 @@ describe.only('services/shantytownComment', () => {
 
                 // output data
                 output = {
+                    watchers: [fakeUser(), fakeUser({ id: 3 }), fakeUser({ id: 4 })],
+                    comment: fakeComment(),
                     commentList: [],
                 };
+
+                // createComment() retourne un id de commentaire
+                dependencies.createComment
+                    .resolves(1);
 
                 // getComments() retourne une liste de commentaires
                 dependencies.getComments
@@ -57,6 +73,16 @@ describe.only('services/shantytownComment', () => {
                     .resolves({
                         [input.shantytown.id]: output.commentList,
                     });
+
+                // findOneComment() retourne un commentaire
+                dependencies.findOneComment
+                    .withArgs(1)
+                    .resolves(output.comment);
+
+                // getShantytownWatchers() retourne une liste d'utilisateurs
+                dependencies.getShantytownWatchers
+                    .withArgs(input.shantytown.id, input.comment.private)
+                    .resolves(output.watchers);
 
                 response = await createComment(input.comment, input.shantytown, input.user);
             });
@@ -78,6 +104,13 @@ describe.only('services/shantytownComment', () => {
                 );
             });
 
+            it('envoie une notification mail', () => {
+                expect(dependencies.sendMail.callCount).to.be.eql(3);
+                expect(dependencies.sendMail).to.have.been.calledWithExactly('new_comment', output.watchers[0], undefined, [input.shantytown, output.comment]);
+                expect(dependencies.sendMail).to.have.been.calledWithExactly('new_comment', output.watchers[1], undefined, [input.shantytown, output.comment]);
+                expect(dependencies.sendMail).to.have.been.calledWithExactly('new_comment', output.watchers[2], undefined, [input.shantytown, output.comment]);
+            });
+
             it('collecte et retourne la liste des commentaires actualisés', async () => {
                 expect(response).to.be.eql(output.commentList);
             });
@@ -96,6 +129,8 @@ describe.only('services/shantytownComment', () => {
                         created_by: user.id,
                     })
                     .rejects(nativeError);
+
+                dependencies.getShantytownWatchers.resolves([]);
             });
 
             it('lance une exception de type ServiceError', async () => {
@@ -119,6 +154,7 @@ describe.only('services/shantytownComment', () => {
             beforeEach(() => {
                 dependencies.triggerNewComment.rejects(nativeError);
                 dependencies.getComments.resolves({ 1: [] });
+                dependencies.getShantytownWatchers.resolves([]);
             });
 
             it('aucune exception est lancée ', async () => {
@@ -141,6 +177,8 @@ describe.only('services/shantytownComment', () => {
                 dependencies.getComments
                     .withArgs(user, [1], false)
                     .rejects(nativeError);
+
+                dependencies.getShantytownWatchers.resolves([]);
             });
 
             it('lance une exception de type ServiceError', async () => {

--- a/test/utils/shantytownComment.js
+++ b/test/utils/shantytownComment.js
@@ -1,0 +1,21 @@
+module.exports = {
+    serialized(override = {}) {
+        const defaultObj = {
+            id: 1,
+            description: 'Un commentaire',
+            createdAt: (new Date(2020, 0, 1, 0, 0, 0)).getTime() / 1000,
+            private: false,
+            createdBy: {
+                id: 2,
+                firstName: 'Jean',
+                lastName: 'Dupont',
+                position: 'Mock',
+                organization: 'DIHAL',
+                organizationId: 2,
+            },
+            shantytown: 1,
+        };
+
+        return Object.assign(defaultObj, override);
+    },
+};


### PR DESCRIPTION
La requête SQL pour récupérer la liste des utilisateurs éligibles au mail était tellement compliqué (surtout pour prendre en compte la dimension "privée" du commentaire : s'il est privé, seuls les utilisateurs disposant des permissions nécessaires sont censés être éligibles) que j'ai fini par faire deux views :
- une view `user_permissions` qui est la liste des permissions *réelles* de chaque utilisateur. Quand je dis *réelle" c'est qu'on prend bien en compte toutes les permissions possibles pour chaque utilisateur (permission du rôle admin s'il en a un, permission du rôle lié à sa structure, et éventuelles permissions personalisées pour sa structure) pour ne retenir que celle qui doit s'appliquer
- une view `shantytown_watchers` qui est la liste des "watchers" (ie. des utilisateurs éligibles à la notification mail) pour chaque site. Cette liste est composée : de tous les intervenants sur le site, et des administrateurs locaux au territoire du site. La view ne retient que les utilisateurs actifs pour ne proposer effectivement que la liste des personnes qui *doivent* recevoir une notification

Tout ce qu'il a resté à faire c'est de rajouter une méthode dans le modèle `userModel` qui s'appelle `getShantytownWatchers` et qui utilise ces deux views pour retourner la liste des utilisateurs à notifier en fonction du site et de si le commentaire est privé ou non.