### PR TITLE
#patch (1013) Ajout d'un graphique avec l'évolution du nombre d'habitants

### DIFF
--- a/server/controllers/statsController.js
+++ b/server/controllers/statsController.js
@@ -19,6 +19,7 @@ module.exports = models => ({
             numberOfCreditsPerYear,
             averageCompletionPercentage,
             numberOfShantytownsOnJune2019,
+            populationTotal,
         ] = await Promise.all([
             models.stats.numberOfPeople(departement),
             models.stats.numberOfShantytown(departement),
@@ -31,6 +32,7 @@ module.exports = models => ({
             models.stats.numberOfCreditsPerYear(departement),
             models.stats.averageCompletionPercentage(departement),
             models.stats.numberOfOpenShantytownsAtMonth(departement, '2019-06-01'),
+            models.stats.populationTotal(departement),
         ]);
 
         return res.status(200).send({
@@ -48,6 +50,7 @@ module.exports = models => ({
                     numberOfCreditsPerYear,
                     averageCompletionPercentage,
                     numberOfShantytownsOnJune2019,
+                    populationTotal,
                 },
             },
         });

--- a/server/models/statsModel.js
+++ b/server/models/statsModel.js
@@ -577,4 +577,142 @@ module.exports = database => ({
     numberOfReviewedComments() {
         return Promise.resolve(-1);
     },
+
+    async populationTotal(departement) {
+        /**
+         * Retourne un objet Date formatté pour toujours correspondre au premier du mois et à 0h 0mn 0s 0ms
+         *
+         * De tels objets permettent de comparer des mois entre eux (le jour et les heures étant égales
+         * par ailleurs).
+         *
+         * @param {Mixed} date N'importe quel paramètre valide pour le constructeur Date
+         *
+         * @returns {Date}
+         */
+        function getMonthlyDate(date) {
+            const d = new Date(date);
+            d.setDate(1);
+            d.setHours(0, 0, 0, 0);
+
+            return d;
+        }
+
+        // on définit les bornes autour desquelles on veut l'évolution de la population, à savoir :
+        // du 1er Mai 2019 au mois précédent (inclus)
+        const min = new Date(2019, 4, 1, 0, 0, 0, 0); // 1er Mai 2019
+        const max = getMonthlyDate(new Date());
+        max.setMonth(max.getMonth() + 1);
+
+        // on initialise l'objet final qui sera retourné (resultArr) avec un total de 0 pour chaque mois
+        // on construit également une table de hashage (result) pour un accès direct à chaque mois plus
+        // loin dans l'algorithme (voir la fonction addPopulation())
+        const result = {};
+        const resultArr = [];
+        for (let d = new Date(min); d < max; d.setMonth(d.getMonth() + 1)) {
+            const obj = {
+                month: toFormat(d, 'M Y'),
+                total: 0,
+            };
+            result[`${d.getFullYear()}-${d.getMonth()}`] = obj;
+            resultArr.push(obj);
+        }
+
+        /**
+         * @param {Number} population Total à rajouter
+         * @param {String} fromStr Date à partir de laquelle il faut augmenter la population (inclus)
+         * @param {String} toStr Date jusqu'à laquelle il faut augmenter la population (exclus : si la date
+         *                       est en Février, le mois de Février est ignoré)
+         */
+        function addPopulation(population, fromStr, toStr) {
+            const from = getMonthlyDate(fromStr);
+            const to = toStr ? getMonthlyDate(toStr) : max;
+
+            const d = new Date(from < min ? min : from);
+            while (d < to && d < max) {
+                result[`${d.getFullYear()}-${d.getMonth()}`].total += population;
+                d.setMonth(d.getMonth() + 1);
+            }
+        }
+
+        // on requête la base de données
+        const rows = await database.query(
+            `SELECT
+            t2.shantytown_id,
+            t2.population_total,
+            t2.closed_at,
+            CASE WHEN t2.asc_rank = '1' THEN t2.opened_at ELSE t2.input_date END AS "ref_date"
+        FROM
+        (
+            SELECT
+                t.shantytown_id,
+                t.population_total,
+                t.input_date,
+                COALESCE(s.built_at, s.declared_at) AS "opened_at",
+                s.closed_at AS "closed_at",
+                RANK() OVER(
+                    PARTITION BY t.shantytown_id ORDER BY t.input_date ASC
+                ) AS "asc_rank",
+                RANK() OVER(
+                    PARTITION BY t.shantytown_id, EXTRACT(YEAR FROM t.input_date), EXTRACT(MONTH FROM t.input_date) ORDER BY t.input_date DESC
+                ) AS "month_rank"
+            FROM (
+                (
+                    SELECT
+                        s.shantytown_id,
+                        population_total,
+                        COALESCE(s.updated_at, s.created_at) AS "input_date"
+                    FROM
+                        shantytowns s
+                )
+                UNION
+                (
+                    SELECT
+                        s.shantytown_id,
+                        population_total,
+                        COALESCE(s.updated_at, s.created_at) AS "input_date"
+                    FROM
+                        "ShantytownHistories" s
+                )
+            ) t
+            LEFT JOIN shantytowns s ON t.shantytown_id = s.shantytown_id
+            LEFT JOIN cities c ON s.fk_city = c.code
+            ${departement ? 'WHERE c.fk_departement = :departement' : ''}
+        ) t2
+        WHERE t2.opened_at IS NOT NULL AND t2.month_rank = '1'
+        ORDER BY t2.shantytown_id ASC, t2.input_date ASC`,
+            {
+                type: database.QueryTypes.SELECT,
+                replacements: {
+                    departement,
+                },
+            },
+        );
+
+        // on traite chaque ligne une par une
+        for (let i = 0; i < rows.length; i += 1) {
+            const {
+                shantytown_id, population_total, closed_at, ref_date,
+            } = rows[i];
+            const next = rows[i + 1];
+
+            // si la population totale est inconnue (ou à 0), on ignore cette saisie
+            if (!population_total) {
+                // eslint-disable-next-line no-continue
+                continue;
+            }
+
+            // nous sommes sur la dernière saisie pour ce site alors on remplit jusqu'au mois de fermeture
+            if (!next || next.shantytown_id !== shantytown_id) {
+                addPopulation(population_total, ref_date, closed_at);
+                // eslint-disable-next-line no-continue
+                continue;
+            }
+
+            // nous ne sommes pas sur la dernière saisie pour ce site alors on remplit du mois de cette
+            // saisie jusqu'au mois de la saisie suivante
+            addPopulation(population_total, ref_date, next.ref_date);
+        }
+
+        return resultArr;
+    },
 });


### PR DESCRIPTION
À jouer pour la mise en prod/préprod : `make prod exec rb_api yarn sequelize db:migrate`

À tester avec la branche côté front : issue/1013
Voir la PR côté front : https://github.com/MTES-MCT/action-bidonvilles/pull/142

D'un point de vue hyper macro, voilà ce qui est fait :
1. On établit les bornes entre lesquelles on veut mesurer l'évolution. En l'occurrence j'ai choisi de Mai 2019 au mois courant.
2. On initialise un tableau avec une entrée par mois dedans, chaque mois étant représenté par un mois au format : `{ month: 'Janvier 2020', total: 0 }`
3. On requête des données pré-traitées :
    - calcul de la date d'"ouverture" du site (`opened_at`) en prenant soit `built_at`soit, en fallback, `declared_at`
    - exclusion des sites pour lesquels `opened_at` n'est pas renseigné
    - calcul de la date de référence à utiliser (`ref_date`), c'est à dire de la date à partir de laquelle la population saisie doit être comptée : pour une déclaration de site, c'est à partir de `opened_at`, pour une modification de site c'est à partir de `updated_at`
    - suppression des éventuels doubles/triples/... saisies pour un même mois pour un site pour ne conserver que la saisie la plus récente pour le mois considéré
    - les résultats sont retournés ordonnés par site puis par date de référence chronologique (c'est à dire de la déclaration à la modification la plus récente). C'est hyper important pour l'algo !
4. On parcourt ces données pour remplir le tableau initialisé plus haut

L'algorithme pour remplir le tableau est "très simple" sur le principe et s'appuie intégralement sur le fait que les données de la requête sont retournées par ordre chronologique.
Pour un site donné :
1. La première saisie correspond à la déclaration du site. On ajoute donc la population déclarée à ce moment là à tous les mois entre le mois d'ouverture du site et le mois de la prochaine saisie (exclus).
2. Pour la seconde saisie on ajoute la population déclarée à ce moment là à tous les mois entre le mois de la saisie et le mois de la prochaine saisie (exclus).
3. Et ainsi de suite jusqu'à la dernière saisie pour laquelle on ajoute la population déclarée à ce moment là à tous les mois entre le mois de la saisie et soit le mois de fermeture du site, soit jusqu'au mois courant.

En procédent ainsi pour tous les sites, on finit par obtenir un total par mois.