### PR TITLE
#patch (hotfix) Redirection des emails vers une adresse test

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -22,6 +22,7 @@ const config = {
     sentry: {
         dsn: process.env.RB_API_SENTRY_DSN || '',
     },
+    testEmail: process.env.RB_API_TEST_EMAIL || null,
 };
 
 let webhookIndex = 1;

--- a/server/controllers/contactController.js
+++ b/server/controllers/contactController.js
@@ -3,18 +3,15 @@ const accessRequestService = require('#server/services/accessRequest/accessReque
 
 const {
     send: sendMail,
-} = require('#server/utils/mail');
-
-const MAIL_TEMPLATES = {};
-MAIL_TEMPLATES.contact_message = require('#server/mails/contact_message');
+    PRESERVE_RECIPIENT,
+} = require('#server/services/mailService');
 
 const sendEmailNewContactMessageToAdmins = async (data, models, contact) => {
     const admins = await models.user.getNationalAdmins();
-    const mailTemplate = MAIL_TEMPLATES.contact_message(data, new Date());
 
     for (let i = 0; i < admins.length; i += 1) {
         // eslint-disable-next-line no-await-in-loop
-        await sendMail(admins[i], mailTemplate, contact);
+        await sendMail('contact_message', admins[i], contact, [data, new Date()], !PRESERVE_RECIPIENT);
     }
 };
 

--- a/server/controllers/inviteController.js
+++ b/server/controllers/inviteController.js
@@ -1,11 +1,9 @@
 const {
     send: sendMail,
-} = require('#server/utils/mail');
+    PRESERVE_RECIPIENT,
+} = require('#server/services/mailService');
 const { triggerPeopleInvitedAlert } = require('#server/utils/slack');
 const { slack: slackConfig } = require('#server/config');
-
-const MAIL_TEMPLATES = {};
-MAIL_TEMPLATES.invitation = require('#server/mails/invitation');
 
 const sendEmailsInvitations = async (guests, greeter) => {
     for (let i = 0; i < guests.length; i += 1) {
@@ -17,7 +15,7 @@ const sendEmailsInvitations = async (guests, greeter) => {
 
         try {
             // eslint-disable-next-line no-await-in-loop
-            await sendMail(guest, MAIL_TEMPLATES.invitation(guest, greeter));
+            await sendMail('invitation', guest, null, [guest, greeter], PRESERVE_RECIPIENT);
         } catch (err) {
             // Ignore
         }

--- a/server/controllers/townController.js
+++ b/server/controllers/townController.js
@@ -8,10 +8,9 @@ const {
 } = require('#db/models');
 const { fromTsToFormat: tsToString, toFormat: dateToString } = require('#server/utils/date');
 const { createExport } = require('#server/utils/excel');
-const { send: sendMail } = require('#server/utils/mail');
+const { send: sendMail, PRESERVE_RECIPIENT } = require('#server/services/mailService');
 const { triggerShantytownCloseAlert, triggerShantytownCreationAlert } = require('#server/utils/slack');
 const { slack: slackConfig } = require('#server/config');
-const COMMENT_DELETION_MAIL = require('#server/mails/comment_deletion.js');
 
 function fromGeoLevelToTableName(geoLevel) {
     switch (geoLevel) {
@@ -478,7 +477,7 @@ module.exports = (models) => {
             }
 
             try {
-                await sendMail(author, COMMENT_DELETION_MAIL(town, comment, message, req.user), req.user);
+                await sendMail('comment_deletion', author, req.user, [town, comment, message, req.user], PRESERVE_RECIPIENT);
             } catch (error) {
                 // ignore
             }

--- a/server/controllers/townController/addActor.js
+++ b/server/controllers/townController/addActor.js
@@ -37,6 +37,7 @@ module.exports = models => async (req, res, next) => {
                     req.user,
                     req.shantytown,
                 ],
+                mailService.PRESERVE_RECIPIENT,
             );
         } catch (error) {
             console.log(error);

--- a/server/controllers/townController/inviteNewActor.js
+++ b/server/controllers/townController/inviteNewActor.js
@@ -14,6 +14,7 @@ module.exports = () => async (req, res, next) => {
                 req.user,
                 req.shantytown,
             ],
+            mailService.PRESERVE_RECIPIENT,
         );
     } catch (error) {
         res.status(500).send({

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -14,13 +14,12 @@ const {
 } = require('#server/utils/auth');
 const {
     send: sendMail,
-} = require('#server/utils/mail');
+    PRESERVE_RECIPIENT,
+} = require('#server/services/mailService');
 const permissionsDescription = require('#server/permissions_description');
 const accessRequestService = require('#server/services/accessRequest/accessRequestService');
 
 const MAIL_TEMPLATES = {};
-MAIL_TEMPLATES.access_granted = require('#server/mails/access_request/user/access_granted');
-MAIL_TEMPLATES.access_denied = require('#server/mails/access_request/user/access_denied');
 MAIL_TEMPLATES.new_password = require('#server/mails/new_password');
 
 const { auth: authConfig } = require('#server/config');
@@ -911,7 +910,7 @@ module.exports = models => ({
         if (user !== null) {
             try {
                 const resetLink = getPasswordResetLink(user);
-                await sendMail(user, MAIL_TEMPLATES.new_password(user, resetLink));
+                await sendMail('new_password', user, null, [user, resetLink], PRESERVE_RECIPIENT);
             } catch (error) {
                 res.status(500).send({
                     error: {

--- a/server/loaders/agendaJobsLoader.js
+++ b/server/loaders/agendaJobsLoader.js
@@ -43,6 +43,7 @@ module.exports = (agenda) => {
                 user,
                 null,
                 [],
+                mailService.PRESERVE_RECIPIENT,
             );
         },
     );

--- a/server/services/accessRequest/mailer.js
+++ b/server/services/accessRequest/mailer.js
@@ -9,6 +9,7 @@ module.exports = {
                     admin,
                     user,
                     [user],
+                    !mailService.PRESERVE_RECIPIENT,
                 )),
             );
         },
@@ -20,6 +21,7 @@ module.exports = {
                     admin,
                     user,
                     [user],
+                    !mailService.PRESERVE_RECIPIENT,
                 )),
             );
         },
@@ -31,6 +33,7 @@ module.exports = {
                     admin,
                     user,
                     [user],
+                    !mailService.PRESERVE_RECIPIENT,
                 )),
             );
         },
@@ -41,6 +44,7 @@ module.exports = {
                 admin,
                 user,
                 [user, submitDate],
+                !mailService.PRESERVE_RECIPIENT,
             );
         },
 
@@ -50,6 +54,7 @@ module.exports = {
                 admin,
                 user,
                 [user],
+                !mailService.PRESERVE_RECIPIENT,
             );
         },
     },
@@ -61,6 +66,7 @@ module.exports = {
                 user,
                 null,
                 [user],
+                mailService.PRESERVE_RECIPIENT,
             );
         },
 
@@ -70,6 +76,7 @@ module.exports = {
                 user,
                 admin,
                 [user, admin],
+                mailService.PRESERVE_RECIPIENT,
             );
         },
 
@@ -79,6 +86,7 @@ module.exports = {
                 user,
                 admin,
                 [admin, activationLink, expiracyDate],
+                mailService.PRESERVE_RECIPIENT,
             );
         },
 
@@ -88,6 +96,7 @@ module.exports = {
                 user,
                 admin,
                 [activationLink, expiracyDate],
+                mailService.PRESERVE_RECIPIENT,
             );
         },
 
@@ -97,12 +106,16 @@ module.exports = {
                 user,
                 admin,
                 [expiracyDate],
+                mailService.PRESERVE_RECIPIENT,
             );
         },
         accessActivated(user) {
             return mailService.send(
                 'access_request/user/access_activated_welcome',
                 user,
+                null,
+                [],
+                mailService.PRESERVE_RECIPIENT,
             );
         },
     },

--- a/server/services/mailService.js
+++ b/server/services/mailService.js
@@ -1,23 +1,42 @@
 /* eslint-disable import/no-dynamic-require */
 /* eslint-disable global-require */
 const { send: sendMail } = require('#server/utils/mail');
+const { testEmail } = require('#server/config');
 
 module.exports = {
+    PRESERVE_RECIPIENT: true,
+
     /**
      * Sends one of the email templates stored in `/mails`
      *
-     * @param {string}    templateName Name of the email template (may be a path, without trailing .js)
-     * @param {User}      recipient    Recipient of the email
-     * @param {User}      [sender]     Sender of the email (used for reply-to)
-     * @param {Array}     templateArgs Arguments to be passed to the email template
+     * @param {string}  templateName Name of the email template (may be a path, without trailing .js)
+     * @param {User}    recipient    Recipient of the email
+     * @param {User}    [sender]     Sender of the email (used for reply-to)
+     * @param {Array}   templateArgs Arguments to be passed to the email template
+     * @param {Boolean} [preserveRecipient=true] Wether the email should be sent to the original
+     *                                           recipient or not (if false, the email is sent to
+     *                                           the test email set in configuration, if any)
      *
      * @returns {Promise}
      */
-    send(templateName, recipient, sender = null, templateArgs) {
+    send(templateName, recipient, sender = null, templateArgs, preserveRecipient = true) {
+        let finalRecipient = recipient;
+        if (preserveRecipient !== true) {
+            if (!testEmail) {
+                return Promise.reject('No test email is setup');
+            }
+
+            finalRecipient = {
+                email: testEmail,
+                first_name: 'Service',
+                last_name: 'Qualité',
+            };
+        }
+
         const templateFn = require(`#server/mails/${templateName}`);
 
         return sendMail(
-            recipient,
+            finalRecipient,
             templateFn.apply(this, templateArgs),
             sender,
         );

--- a/server/services/shantytownComment/createComment.js
+++ b/server/services/shantytownComment/createComment.js
@@ -50,7 +50,7 @@ module.exports = async (comment, shantytown, author) => {
         if (watchers.length > 0) {
             const serializedComment = await shantytownCommentModel.findOne(commentId);
             await Promise.all(
-                watchers.map(user => mailService.send('new_comment', user, undefined, [shantytown, serializedComment])),
+                watchers.map(user => mailService.send('new_comment', user, undefined, [shantytown, serializedComment], !mailService.PRESERVE_RECIPIENT)),
             );
         }
     } catch (error) {

--- a/test/suites/server/controllers/contactController/contact.spec.js
+++ b/test/suites/server/controllers/contactController/contact.spec.js
@@ -50,7 +50,7 @@ const emailStub = sinon.stub();
 
 
 const mockModels = {
-    '#server/utils/mail': {
+    '#server/services/mailService': {
         send: emailStub,
     },
     '#server/services/accessRequest/accessRequestService': {

--- a/test/suites/server/services/shantytownComment/createComment.spec.js
+++ b/test/suites/server/services/shantytownComment/createComment.spec.js
@@ -106,9 +106,9 @@ describe.only('services/shantytownComment', () => {
 
             it('envoie une notification mail', () => {
                 expect(dependencies.sendMail.callCount).to.be.eql(3);
-                expect(dependencies.sendMail).to.have.been.calledWithExactly('new_comment', output.watchers[0], undefined, [input.shantytown, output.comment]);
-                expect(dependencies.sendMail).to.have.been.calledWithExactly('new_comment', output.watchers[1], undefined, [input.shantytown, output.comment]);
-                expect(dependencies.sendMail).to.have.been.calledWithExactly('new_comment', output.watchers[2], undefined, [input.shantytown, output.comment]);
+                expect(dependencies.sendMail).to.have.been.calledWithExactly('new_comment', output.watchers[0], undefined, [input.shantytown, output.comment], false);
+                expect(dependencies.sendMail).to.have.been.calledWithExactly('new_comment', output.watchers[1], undefined, [input.shantytown, output.comment], false);
+                expect(dependencies.sendMail).to.have.been.calledWithExactly('new_comment', output.watchers[2], undefined, [input.shantytown, output.comment], false);
             });
 
             it('collecte et retourne la liste des commentaires actualisés', async () => {


### PR DESCRIPTION
- passage par le mailService pour envoyer tous les mails
- ajout d'un paramètre à la méthode `mailService.send()` pour indiquer si le destinataire du mail doit être préservé en préprod, ou s'il doit être remplacé par un destinataire de test
- ajout d'une entrée en configuration pour définir le destinataire de test
- mise à jour des appels à `mailService.send()` partout dans l'application pour indiquer si oui ou non le destinataire du mail peut être préservé dans le cas de figure concerné
- mise à jour des tests unitaires en conséquence